### PR TITLE
Add support for course shortcodes

### DIFF
--- a/actions/course.js
+++ b/actions/course.js
@@ -13,9 +13,7 @@ export function createCourse(course) {
   return (dispatch) => {
     dispatch(createCourseRequest(course))
 
-    return axios.post('/api/courses', {
-      name: course.name,
-    }).then(
+    return axios.post('/api/courses', course).then(
       res => dispatch(createCourseSuccess(res.data)),
       (err) => {
         console.error(err)

--- a/api/courses.js
+++ b/api/courses.js
@@ -66,11 +66,13 @@ router.get('/:courseId', [
 router.post('/', [
   requireAdmin,
   check('name', 'name must be specified').exists(),
+  check('shortcode', 'shortcode must be specified').exists(),
   failIfErrors,
 ], async (req, res, _next) => {
-  const { name } = matchedData(req)
+  const { name, shortcode } = matchedData(req)
   const course = Course.build({
     name,
+    shortcode,
   })
   const newCourse = await course.save()
   res.status(201).send(newCourse)

--- a/app.js
+++ b/app.js
@@ -49,4 +49,7 @@ app.use(`${baseUrl}/api/courses/:courseId/queues`, require('./api/queues'))
 app.use(`${baseUrl}/api/courses/:courseId/queues/:queueId/questions`, require('./api/questions'))
 app.use(`${baseUrl}/api/queues/:queueId/questions`, require('./api/questions'))
 
+// Support for course shortcodes
+app.use(`${baseUrl}/:courseCode`, require('./middleware/courseShortcodes'))
+
 module.exports = app

--- a/components/NewCourse.js
+++ b/components/NewCourse.js
@@ -6,6 +6,7 @@ import {
   Form,
   FormGroup,
   FormFeedback,
+  FormText,
   Label,
   Input,
   Button,
@@ -17,6 +18,7 @@ class NewCourse extends React.Component {
 
     this.state = {
       name: '',
+      shortcode: '',
       isFieldValid: {},
     }
 
@@ -31,19 +33,26 @@ class NewCourse extends React.Component {
   }
 
   handleCreateCourse() {
-    if (!this.state.name) {
-      this.setState({
-        isFieldValid: {
-          name: false,
-        },
-      })
-    } else {
-      const course = {
-        name: this.state.name,
-      }
+    let valid = true
+    const isFieldValid = {};
 
-      this.props.onCreateCourse(course)
+    ['name', 'shortcode'].forEach((field) => {
+      if (!this.state[field]) {
+        valid = false
+        isFieldValid[field] = false
+      }
+    })
+    if (!valid) {
+      this.setState({ isFieldValid })
+      return
     }
+
+    const course = {
+      name: this.state.name,
+      shortcode: this.state.shortcode,
+    }
+
+    this.props.onCreateCourse(course)
   }
 
   render() {
@@ -51,8 +60,8 @@ class NewCourse extends React.Component {
       <ListGroupItem>
         <Form autoComplete="off">
           <FormGroup row>
-            <Label for="name" sm={2}>Name</Label>
-            <Col sm={10}>
+            <Label for="name" sm={3}>Name</Label>
+            <Col sm={9}>
               <Input
                 name="name"
                 id="name"
@@ -62,6 +71,25 @@ class NewCourse extends React.Component {
                 valid={this.state.isFieldValid.name}
               />
               <FormFeedback>A name is required</FormFeedback>
+            </Col>
+          </FormGroup>
+          <FormGroup row>
+            <Label for="name" sm={3}>Shortcode</Label>
+            <Col sm={9}>
+              <Input
+                name="shortcode"
+                id="shortcode"
+                placeholder="Enter a course shortcode (e.g. cs225)"
+                value={this.state.shortcode}
+                onChange={this.handleInputChange}
+                valid={this.state.isFieldValid.shortcode}
+              />
+              <FormFeedback>A shortcode is required!</FormFeedback>
+              <FormText>
+                Adding a shortcode will allow you to generate a special link
+                that will direct students to your currently open queue when they
+                visit it.
+              </FormText>
             </Col>
           </FormGroup>
           <FormGroup row className="mb-0">

--- a/middleware/courseShortcodes.js
+++ b/middleware/courseShortcodes.js
@@ -1,0 +1,31 @@
+const { baseUrl } = require('../util')
+const { Course, Queue } = require('../models')
+
+module.exports = async (req, res, next) => {
+  const { courseCode: shortcode } = req.params
+  const course = await Course.findOne({
+    where: {
+      shortcode,
+    },
+  })
+  if (!course) {
+    next()
+    return
+  }
+
+  // Find the most recent open queue for this course
+  const queue = await Queue.findAll({
+    where: {
+      courseId: course.id,
+    },
+    order: [
+      ['id', 'DESC'],
+    ],
+  })
+
+  if (queue.length === 1) {
+    res.redirect(`${baseUrl}/queue/${queue[0].id}`)
+  } else {
+    res.redirect(`${baseUrl}/course/${course.id}`)
+  }
+}

--- a/models/Course.js
+++ b/models/Course.js
@@ -1,6 +1,7 @@
 module.exports = (sequelize, DataTypes) => {
   const obj = sequelize.define('course', {
     name: DataTypes.STRING,
+    shortcode: DataTypes.STRING,
   })
 
   obj.associate = (models) => {


### PR DESCRIPTION
This adds support for course shortcodes. This allows us to have links like `edu.cs.illinois.edu/queue/cs225`. This link will direct the visitor to the current queue if there is only one queue, or will send them to the course page if the course has multiple queues.

This PR makes the assumption that we'll trust whoever is creating shortcodes (aka admins). To avoid having to duplicate next.js routing behavior and rely on private APIs, the shortcode middleware runs **before** any next.js route handling. This simplifies things, but could also potentially allow a malicious person to hijack an important route. Thankfully, express only allows `[a-zA-Z0-9_]` in route params, so this is mostly safe.

On the offchance that we have to revert to the slightly hacky way, the following `server.js` was working at the time of PR:

```
/* eslint global-require: "off", no-console: "off" */
const app = require('./app')
const server = require('http').Server(app)
const io = require('socket.io')
const nextJs = require('next')
const co = require('co')

const routes = require('./routes')
const serverSocket = require('./socket/server')
const { baseUrl } = require('./util')

require('dotenv').config()

const DEV = process.env.NODE_ENV !== 'production'
const PORT = process.env.PORT || 3000

const nextApp = nextJs({ dev: DEV })

/* eslint-disable func-names */
co(function* () {
  // Initialize the Next.js app
  yield nextApp.prepare()

  // Websocket stuff
  const socket = io(server, { path: `${baseUrl}/socket.io` })
  serverSocket(socket)

  // A bit ugly, but we need to ensure all other routes are processed before we
  // try to run the URL shortcodes route. We duplicate the 
  app.use(async (req, res, next) => {
    const { route, query, parsedUrl } = routes.match(req.url)
    if (route) {
      nextApp.render(req, res, route.page, query)
      return
    }

    if (nextApp.hotReloader) {
      await nextApp.hotReloader.run(req, res)
    }

    const nextFn = nextApp.router.match(req, res, parsedUrl)
    if (nextFn) {
      nextFn()
      return
    }

    next()
  })


  server.listen(PORT)
  console.log(`Listening on ${PORT}`)
}).catch(error => console.error(error.stack))
```

Fixes #22 