### PR TITLE
Make dotenv setup the first thing to execute when starting the app

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,4 +1,6 @@
 /* eslint global-require: "off", no-console: "off" */
+require('dotenv').config()
+
 const app = require('./app')
 const server = require('http').Server(app)
 const io = require('socket.io')
@@ -8,8 +10,6 @@ const co = require('co')
 const routes = require('./routes')
 const serverSocket = require('./socket/server')
 const { baseUrl } = require('./util')
-
-require('dotenv').config()
 
 const DEV = process.env.NODE_ENV !== 'production'
 const PORT = process.env.PORT || 3000


### PR DESCRIPTION
We need to make sure that `process.env` is completely set up before we start doing anything, given that `app.js` and middleware could depend on environment variables.