### PR TITLE
[WIP] Redirect Non Existent Queues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ with the current date and the next changes should go under a **[Next]** header.
 
 * Add changelog. ([@nwalters512](https://github.com/nwalters512) in [#34](https://github.com/illinois/queue/pull/34))
 * Add Travis and Prettier support. ([@nwalters512](https://github.com/nwalters512) in [#37](https://github.com/illinois/queue/pull/37))
-* Allow course staff to see netids next to student name ([@genevievehelsel](https://github.com/genevievehelsel) in [#32](https://github.com/illinois/queue/pull/32))
+* Allow course staff to see netids next to student name. ([@genevievehelsel](https://github.com/genevievehelsel) in [#32](https://github.com/illinois/queue/pull/32))
+* Automatically redirect to a current queue or course page if visiting a closed queue. ([@Muakasan](https://github.com/Muakasan) in [#40](https://github.com/illinois/queue/pull/40))
+
 
 ## 27 February 2018
 

--- a/app.js
+++ b/app.js
@@ -57,4 +57,7 @@ app.use(`${baseUrl}/api/queues/:queueId/questions`, require('./api/questions'))
 // Support for course shortcodes
 app.use(`${baseUrl}/:courseCode`, require('./middleware/courseShortcodes'))
 
+// Support for redirects of nonexistent queues
+app.use(`${baseUrl}/queue/:queueId`, require('./middleware/redirectNoQueue'))
+
 module.exports = app

--- a/middleware/redirectNoQueue.js
+++ b/middleware/redirectNoQueue.js
@@ -11,26 +11,24 @@ module.exports = async (req, res, next) => {
   })
   console.log(firstQueue)
   
-  //Cannot Find Queue In Deleted or Non Deleted
+  // Cannot Find Queue In Deleted or Non Deleted
   if(!firstQueue){
     res.redirect(`${baseUrl}/`)
   }
 
-  //Deleted Queue
+  // Deleted Queue
   if (firstQueue.dataValues.deletedAt) {
     // Find the most recent open queue for this course
     const sameCourseQueues = await Queue.findAll({
       where: {
         courseId: firstQueue.dataValues.courseId,
-      },
-      order: [['id', 'DESC']],
+      }
     })
 
+    // Redirect to Queue from the same Course
     if (sameCourseQueues.length === 1) {
-      console.log("TO SAME COURSE QUEUE")
       res.redirect(`${baseUrl}/queue/${sameCourseQueues[0].id}`)
-    } else {
-      console.log("TO THE COURSE")
+    } else { // Redirect to the Course the Queue was fron
       res.redirect(`${baseUrl}/course/${firstQueue.dataValues.courseId}`)
     }
   }

--- a/middleware/redirectNoQueue.js
+++ b/middleware/redirectNoQueue.js
@@ -1,17 +1,17 @@
 const { baseUrl } = require('../util')
-const { Course, Queue } = require('../models')
+const { Queue } = require('../models')
 
 module.exports = async (req, res, next) => {
   const { queueId: qid } = req.params
   const firstQueue = await Queue.findOne({
     where: {
-      id: qid
+      id: qid,
     },
-    paranoid: false
+    paranoid: false,
   })
-  
+
   // Cannot Find Queue In Deleted or Non Deleted
-  if(!firstQueue){
+  if (!firstQueue) {
     res.redirect(`${baseUrl}/`)
   }
 
@@ -21,17 +21,17 @@ module.exports = async (req, res, next) => {
     const sameCourseQueues = await Queue.findAll({
       where: {
         courseId: firstQueue.dataValues.courseId,
-      }
+      },
     })
 
     // Redirect to Queue from the same Course
     if (sameCourseQueues.length === 1) {
       res.redirect(`${baseUrl}/queue/${sameCourseQueues[0].id}`)
-    } else { // Redirect to the Course the Queue was fron
+    } else {
+      // Redirect to the Course the Queue was fron
       res.redirect(`${baseUrl}/course/${firstQueue.dataValues.courseId}`)
     }
-  }
-  else {
+  } else {
     next()
   }
 }

--- a/middleware/redirectNoQueue.js
+++ b/middleware/redirectNoQueue.js
@@ -13,14 +13,15 @@ module.exports = async (req, res, next) => {
   // Cannot Find Queue In Deleted or Non Deleted
   if (!firstQueue) {
     res.redirect(`${baseUrl}/`)
+    return
   }
 
   // Deleted Queue
-  if (firstQueue.dataValues.deletedAt) {
+  if (firstQueue.deletedAt) {
     // Find the most recent open queue for this course
     const sameCourseQueues = await Queue.findAll({
       where: {
-        courseId: firstQueue.dataValues.courseId,
+        courseId: firstQueue.courseId,
       },
     })
 
@@ -29,9 +30,9 @@ module.exports = async (req, res, next) => {
       res.redirect(`${baseUrl}/queue/${sameCourseQueues[0].id}`)
     } else {
       // Redirect to the Course the Queue was fron
-      res.redirect(`${baseUrl}/course/${firstQueue.dataValues.courseId}`)
+      res.redirect(`${baseUrl}/course/${firstQueue.courseId}`)
     }
-  } else {
-    next()
+    return
   }
+  next()
 }

--- a/middleware/redirectNoQueue.js
+++ b/middleware/redirectNoQueue.js
@@ -1,0 +1,40 @@
+const { baseUrl } = require('../util')
+const { Course, Queue } = require('../models')
+
+module.exports = async (req, res, next) => {
+  const { queueId: qid } = req.params
+  const firstQueue = await Queue.findOne({
+    where: {
+      id: qid
+    },
+    paranoid: false
+  })
+  console.log(firstQueue)
+  
+  //Cannot Find Queue In Deleted or Non Deleted
+  if(!firstQueue){
+    res.redirect(`${baseUrl}/`)
+  }
+
+  //Deleted Queue
+  if (firstQueue.dataValues.deletedAt) {
+    // Find the most recent open queue for this course
+    const sameCourseQueues = await Queue.findAll({
+      where: {
+        courseId: firstQueue.dataValues.courseId,
+      },
+      order: [['id', 'DESC']],
+    })
+
+    if (sameCourseQueues.length === 1) {
+      console.log("TO SAME COURSE QUEUE")
+      res.redirect(`${baseUrl}/queue/${sameCourseQueues[0].id}`)
+    } else {
+      console.log("TO THE COURSE")
+      res.redirect(`${baseUrl}/course/${firstQueue.dataValues.courseId}`)
+    }
+  }
+  else {
+    next()
+  }
+}

--- a/middleware/redirectNoQueue.js
+++ b/middleware/redirectNoQueue.js
@@ -9,7 +9,6 @@ module.exports = async (req, res, next) => {
     },
     paranoid: false
   })
-  console.log(firstQueue)
   
   // Cannot Find Queue In Deleted or Non Deleted
   if(!firstQueue){

--- a/middleware/redirectNoQueue.test.js
+++ b/middleware/redirectNoQueue.test.js
@@ -1,0 +1,65 @@
+/* eslint-env jest */
+const redirectNoQueue = require('./redirectNoQueue')
+const testutil = require('../testutil')
+const { Queue } = require('../models')
+
+beforeEach(async () => {
+  await testutil.setupTestDb()
+  await testutil.populateTestDb()
+})
+afterEach(() => testutil.destroyTestDb())
+
+const makeArgs = queueId => {
+  const req = {
+    params: {
+      queueId,
+    },
+  }
+
+  const res = {
+    redirect: jest.fn(),
+  }
+
+  const next = jest.fn()
+
+  return { req, res, next }
+}
+
+describe('redirectNoQueue middleware', () => {
+  test('redirects to homepage if queue never existed', async () => {
+    const { req, res, next } = makeArgs(1234)
+    await redirectNoQueue(req, res, next)
+    expect(res.redirect).toBeCalledWith('/')
+    expect(next).not.toBeCalled()
+  })
+
+  test('redirects to course page if 2+ active queues', async () => {
+    // Make a few new queues for 225 and delete the original one
+    await Queue.bulkCreate([
+      { name: 'CS225 Queue #2', courseId: 1 },
+      { name: 'CS225 Queue #3', courseId: 1 },
+    ])
+    await Queue.destroy({ where: { id: 1 } })
+    const { req, res, next } = makeArgs(1)
+    await redirectNoQueue(req, res, next)
+    expect(res.redirect).toBeCalledWith('/course/1')
+    expect(next).not.toBeCalled()
+  })
+
+  test('redirects to active queue if only one exists', async () => {
+    // Make a few new queues for 225 and delete the original one
+    await Queue.bulkCreate([{ name: 'CS225 Queue #2', courseId: 1 }])
+    await Queue.destroy({ where: { id: 1 } })
+    const { req, res, next } = makeArgs(1)
+    await redirectNoQueue(req, res, next)
+    expect(res.redirect).toBeCalledWith('/queue/3')
+    expect(next).not.toBeCalled()
+  })
+
+  test('does nothing if requested queue is open', async () => {
+    const { req, res, next } = makeArgs(1)
+    await redirectNoQueue(req, res, next)
+    expect(res.redirect).not.toBeCalled()
+    expect(next).toBeCalled()
+  })
+})


### PR DESCRIPTION
When visiting the URL of a deleted Queue, it tries to redirect you to the correct place.
1. If a queue exists from the same course as the queue you tried to visit, it will redirect you to that queue
2. Else it will redirect you to the course page of the queue you tried to visit

Current Bug: Redirect leads to correct URL but 404
Steps to Reproduce:
1. Create a Course
2. Create a Queue
3. Create another Queue
4. Delete one of the 2 Queues
5. Go to the URL of the deleted queue

Resolves #38 