### PR TITLE
Run "npm run build" on Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: node_js
 node_js:
   - "node"
 script:
+  - npm run build
   - npm run test
   - npm run lint-js
   - npm run prettier-diff


### PR DESCRIPTION
This runs `npm run build` during CI to ensure that our frontend statics can be built successfully. Fixes #39.