### PR TITLE
Remove extraneous div that was causing styling issues

### DIFF
--- a/pages/courseStaff.js
+++ b/pages/courseStaff.js
@@ -74,11 +74,9 @@ class CourseStaff extends React.Component {
       })
     } else {
       users = (
-        <div>
-          <ListGroupItem className="text-center text-muted pt-4 pb-4">
-            This course doesn&apos;t have any staff yet
-          </ListGroupItem>
-        </div>
+        <ListGroupItem className="text-center text-muted pt-4 pb-4">
+          This course doesn&apos;t have any staff yet
+        </ListGroupItem>
       )
     }
 


### PR DESCRIPTION
This is me being nitpicky, but the line between the add staff box and "no staff" message only appeared on hover. It's now shown always, like it should be.