### PR TITLE
Show question elapsed answering time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ with the current date and the next changes should go under a **[Next]** header.
 * Automatically redirect to a current queue or course page if visiting a closed queue. ([@Muakasan](https://github.com/Muakasan) in [#40](https://github.com/illinois/queue/pull/40))
 * Rebrand from CS@Illinois Queues to Queues@Illinois. ([@genevievehelsel](https://github.com/genevievehelsel) in [#42](https://github.com/illinois/queue/pull/42))
 * Add web manifest for "Add to Home Screen" on Android. ([@shreyas208](https://github.com/shreyas208) in [#29](https://github.com/illinois/queue/pull/29))
+* Show course staff and asker how long question has been being answered for. ([@nwalters512](https://github.com/nwalters512) in [#46](https://github.com/illinois/queue/pull/46))
 
 ## 27 February 2018
 

--- a/api/questions.test.js
+++ b/api/questions.test.js
@@ -244,7 +244,7 @@ describe('Questions API', () => {
       expect(res.body.askedBy.netid).toBe('admin')
       expect(res.body.beingAnswered).toBe(false)
       expect(res.body.answerStartTime).toBe(null)
-      expect(res.body.answerEndTime).toBe(null)
+      expect(res.body.answerFinishTime).toBe(null)
     })
 
     test('succeeds for course staff', async () => {
@@ -256,7 +256,7 @@ describe('Questions API', () => {
       expect(res.body.askedBy.netid).toBe('admin')
       expect(res.body.beingAnswered).toBe(false)
       expect(res.body.answerStartTime).toBe(null)
-      expect(res.body.answerEndTime).toBe(null)
+      expect(res.body.answerFinishTime).toBe(null)
     })
 
     test('fails for student', async () => {

--- a/api/questions.test.js
+++ b/api/questions.test.js
@@ -212,6 +212,7 @@ describe('Questions API', () => {
       expect(res.body).toHaveProperty('askedBy')
       expect(res.body.askedBy.netid).toBe('admin')
       expect(res.body.beingAnswered).toBe(true)
+      expect(res.body.questionStartTime).not.toBe(null)
     })
 
     test('succeeds for course staff', async () => {
@@ -222,6 +223,7 @@ describe('Questions API', () => {
       expect(res.body).toHaveProperty('askedBy')
       expect(res.body.askedBy.netid).toBe('admin')
       expect(res.body.beingAnswered).toBe(true)
+      expect(res.body.questionStartTime).not.toBe(null)
     })
 
     test('fails for student', async () => {
@@ -241,6 +243,8 @@ describe('Questions API', () => {
       expect(res.body).toHaveProperty('askedBy')
       expect(res.body.askedBy.netid).toBe('admin')
       expect(res.body.beingAnswered).toBe(false)
+      expect(res.body.answerStartTime).toBe(null)
+      expect(res.body.answerEndTime).toBe(null)
     })
 
     test('succeeds for course staff', async () => {
@@ -251,6 +255,8 @@ describe('Questions API', () => {
       expect(res.body).toHaveProperty('askedBy')
       expect(res.body.askedBy.netid).toBe('admin')
       expect(res.body.beingAnswered).toBe(false)
+      expect(res.body.answerStartTime).toBe(null)
+      expect(res.body.answerEndTime).toBe(null)
     })
 
     test('fails for student', async () => {

--- a/components/CountUpTimer.js
+++ b/components/CountUpTimer.js
@@ -1,0 +1,55 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import moment from 'moment'
+import mdf from 'moment-duration-format'
+
+mdf(moment)
+
+class CountUpTimer extends React.Component {
+  constructor(props) {
+    super(props)
+
+    this.state = {
+      time: '00:00',
+    }
+
+    this.interval = null
+  }
+
+  componentDidMount() {
+    this.interval = setInterval(this.update.bind(this), 100)
+    this.update()
+  }
+
+  componentWillUnmount() {
+    if (this.interval) {
+      clearInterval(this.interval)
+      this.interval = null
+    }
+  }
+
+  update() {
+    const start = moment(this.props.startTime)
+    const diff = moment
+      .duration(moment().diff(start))
+      .format('mm:ss', { trim: false })
+    this.setState({ time: diff })
+  }
+
+  render() {
+    // eslint-disable-next-line no-unused-vars
+    const { startTime, tag: Tag, ...rest } = this.props
+    return <Tag {...rest}>{this.state.time}</Tag>
+  }
+}
+
+CountUpTimer.defaultProps = {
+  tag: 'div',
+}
+
+CountUpTimer.propTypes = {
+  startTime: PropTypes.string.isRequired,
+  tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
+}
+
+export default CountUpTimer

--- a/components/Question.js
+++ b/components/Question.js
@@ -4,6 +4,7 @@ import { ListGroupItem, Button, Badge } from 'reactstrap'
 import Moment from 'react-moment'
 import moment from 'moment'
 
+import CountUpTimer from './CountUpTimer'
 import ParrotText from './ParrotText'
 
 /* eslint-disable react/prefer-stateless-function */
@@ -16,6 +17,7 @@ class Question extends React.Component {
       topic,
       beingAnswered,
       enqueueTime,
+      answerStartTime,
       answeredBy,
       askedBy,
       isUserCourseStaff,
@@ -153,7 +155,20 @@ class Question extends React.Component {
               <ParrotText text={topic} />
             </div>
           </div>
-          <div className="ml-auto pt-3 pt-sm-0">{buttonCluster}</div>
+          <div className="ml-auto pt-3 pt-sm-0">
+            {buttonCluster}
+            {userCanDelete &&
+              beingAnswered && (
+                <div className="text-muted mt-2">
+                  elapsed answering time:
+                  <CountUpTimer
+                    startTime={answerStartTime}
+                    tag="span"
+                    className="ml-1"
+                  />
+                </div>
+              )}
+          </div>
         </ListGroupItem>
       </Fragment>
     )
@@ -162,6 +177,7 @@ class Question extends React.Component {
 
 Question.defaultProps = {
   answeredBy: null,
+  answerStartTime: null,
 }
 
 Question.propTypes = {
@@ -171,6 +187,7 @@ Question.propTypes = {
   topic: PropTypes.string.isRequired,
   beingAnswered: PropTypes.bool.isRequired,
   enqueueTime: PropTypes.string.isRequired,
+  answerStartTime: PropTypes.string,
   answeredBy: PropTypes.shape({
     name: PropTypes.string,
     netid: PropTypes.string,

--- a/components/QuestionBeingAnsweredPanel.js
+++ b/components/QuestionBeingAnsweredPanel.js
@@ -1,0 +1,38 @@
+import React, { Fragment } from 'react'
+import PropTypes from 'prop-types'
+import { connect } from 'react-redux'
+import { Card, CardTitle } from 'reactstrap'
+
+import CountUpTimer from './CountUpTimer'
+
+const ActiveQuestionPanel = ({ question }) => (
+  <Fragment>
+    <Card body inverse color="success">
+      <CardTitle className="mb-4">
+        {question.answeredBy.name} is answering your question!
+      </CardTitle>
+      <span>elapsed time:</span>
+      <CountUpTimer startTime={question.answerStartTime} className="h1 mb-0" />
+    </Card>
+  </Fragment>
+)
+
+ActiveQuestionPanel.defaultProps = {
+  question: {},
+}
+
+/* eslint-disable react/no-unused-prop-types */
+ActiveQuestionPanel.propTypes = {
+  questionId: PropTypes.number.isRequired,
+  question: PropTypes.shape({
+    answeredBy: PropTypes.shape({
+      name: PropTypes.string,
+    }),
+  }),
+}
+
+const mapStateToProps = (state, ownProps) => ({
+  question: state.questions.questions[ownProps.questionId],
+})
+
+export default connect(mapStateToProps, null)(ActiveQuestionPanel)

--- a/components/QuestionPanel.js
+++ b/components/QuestionPanel.js
@@ -5,10 +5,21 @@ import { connect } from 'react-redux'
 import { getUserActiveQuestionIdForQueue } from '../selectors'
 
 import ActiveQuestionPanel from './ActiveQuestionPanel'
+import QuestionBeingAnsweredPanel from './QuestionBeingAnsweredPanel'
 import NewQuestionContainer from '../containers/NewQuestionContainer'
 
-const QuestionPanel = ({ queueId, user, userActiveQuestionId }) => {
+const QuestionPanel = ({ queueId, user, questions, userActiveQuestionId }) => {
   if (userActiveQuestionId !== -1) {
+    const question = questions[userActiveQuestionId]
+    if (question.answeredById) {
+      // The question is currently being answered
+      return (
+        <QuestionBeingAnsweredPanel
+          queueId={queueId}
+          questionId={userActiveQuestionId}
+        />
+      )
+    }
     return (
       <ActiveQuestionPanel
         queueId={queueId}
@@ -19,17 +30,27 @@ const QuestionPanel = ({ queueId, user, userActiveQuestionId }) => {
   return <NewQuestionContainer queueId={queueId} user={user} />
 }
 
+QuestionPanel.defaultProps = {
+  questions: {},
+}
+
 QuestionPanel.propTypes = {
   queueId: PropTypes.number.isRequired,
   user: PropTypes.shape({
     name: PropTypes.string,
   }).isRequired,
+  questions: PropTypes.objectOf(
+    PropTypes.shape({
+      answeredById: PropTypes.number,
+    })
+  ),
   userActiveQuestionId: PropTypes.number.isRequired,
 }
 
 const mapStateToProps = (state, ownProps) => ({
   user: state.user.user,
   userActiveQuestionId: getUserActiveQuestionIdForQueue(state, ownProps),
+  questions: state.questions.questions,
 })
 
 export default connect(mapStateToProps, null)(QuestionPanel)

--- a/package-lock.json
+++ b/package-lock.json
@@ -7550,6 +7550,11 @@
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.20.1.tgz",
       "integrity": "sha512-Yh9y73JRljxW5QxN08Fner68eFLxM5ynNOAw2LbIB1YAGeQzZT8QFSUvkAz609Zf+IHhhaUxqZK8dG3W/+HEvg=="
     },
+    "moment-duration-format": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/moment-duration-format/-/moment-duration-format-2.2.2.tgz",
+      "integrity": "sha1-uVdhLeJgFsmtnrYIfAVFc+USd3k="
+    },
     "moment-timezone": {
       "version": "0.5.14",
       "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.14.tgz",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "isomorphic-unfetch": "^2.0.0",
     "json-patch": "^0.7.0",
     "moment": "^2.20.1",
+    "moment-duration-format": "^2.2.2",
     "mysql2": "^1.5.2",
     "next": "^5.0.0",
     "next-redux-wrapper": "^1.3.5",


### PR DESCRIPTION
Show the elapsed time since a question started being answered to course staff and the person asking the question.

Any alternative suggestions for UI are welcome!

Student view:

<img width="899" alt="screen shot 2018-03-05 at 12 47 41 am" src="https://user-images.githubusercontent.com/1476544/36961009-0972a2f0-200f-11e8-96d7-3a91577fb755.png">

Staff view:

<img width="604" alt="screen shot 2018-03-05 at 12 45 44 am" src="https://user-images.githubusercontent.com/1476544/36961015-11afe964-200f-11e8-85d8-4a168149d250.png">


Fixes #10 