### PR TITLE
Updated eslint config to remove unnecessary warnings

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,7 +6,7 @@ module.exports = {
       { args: 'after-used', argsIgnorePattern: '^_' },
     ],
     'react/jsx-filename-extension': ['error', { extensions: ['.js', '.jsx'] }],
-    'no-console': ['warn'],
+    'no-console': ['error', { allow: ['error'] }],
     'arrow-body-style': ['off'],
     'jsx-a11y/anchor-is-valid': [
       'error',

--- a/components/PageWithUser.js
+++ b/components/PageWithUser.js
@@ -41,7 +41,7 @@ export default function(AuthedComponent, permissions) {
           } else if (requireCourseStaff) {
             // We should have received a courseId prop...
             if (!this.props.courseId) {
-              console.warn(
+              console.error(
                 'PageWithUser requested course staff authz, but no courseId was provided'
               )
               authzed = false


### PR DESCRIPTION
- The `no-console` rule now ignores `console.error()`, which we intentionally use for error logging.
- The `no-console` rule now generates an error instead of a warning for non-ignored console statements.
- Changed a console warning in PageWithUser to an error.