### PR TITLE
Add bottom margin to homepage course buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ with the current date and the next changes should go under a **[Next]** header.
 
 ## [Next]
 
+* Improve spacing of course buttons on homepage. ([@nwalters512](https://github.com/nwalters512) in [#60](https://github.com/illinois/queue/pull/60))
+
 ## 13 March 2018
 
 * Add changelog. ([@nwalters512](https://github.com/nwalters512) in [#34](https://github.com/illinois/queue/pull/34))

--- a/pages/index.js
+++ b/pages/index.js
@@ -117,7 +117,7 @@ class Index extends React.Component {
           prefetch
           passHref
         >
-          <Button color="primary" tag="a" className="mr-3" outline>
+          <Button color="primary" tag="a" className="mr-3 mb-3" outline>
             {course.name}
           </Button>
         </Link>
@@ -221,7 +221,7 @@ class Index extends React.Component {
               </CardBody>
             </Card>
           )}
-          <div className="mb-4">{courseButtons}</div>
+          <div className="mb-1">{courseButtons}</div>
         </Container>
         {this.state.showDeleteQueueModal && (
           <ConfirmDeleteQueueModal


### PR DESCRIPTION
**Before:**
<img width="300" alt="screen shot 2018-03-15 at 12 52 44 am" src="https://user-images.githubusercontent.com/1476544/37446514-5ab10704-27eb-11e8-89d9-3a9aee1f6dbb.png">

**After:**
<img width="300" alt="screen shot 2018-03-15 at 12 53 26 am" src="https://user-images.githubusercontent.com/1476544/37446519-61b3ed3c-27eb-11e8-8a56-7b5a27b5693e.png">

Fixes #59 