### PR TITLE
Trim spaces from netids when adding course staff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ with the current date and the next changes should go under a **[Next]** header.
 ## [Next]
 
 * Improve spacing of course buttons on homepage. ([@nwalters512](https://github.com/nwalters512) in [#60](https://github.com/illinois/queue/pull/60))
+* Trim whitespace from netids when adding course staff. ([@nwalters512](https://github.com/nwalters512) in [#67](https://github.com/illinois/queue/pull/67))
 
 ## 13 March 2018
 
@@ -31,7 +32,6 @@ with the current date and the next changes should go under a **[Next]** header.
 * Allow student to edit topic and location of a qeustion that's already on the queue. ([@genevievehelsel](https://github.com/genevievehelsel) in [#18](https://github.com/illinois/queue/pull/18))
 * Add support for course shortcodes. ([@nwalters512](https://github.com/nwalters512) in [#26](https://github.com/illinois/queue/pull/26))
 * Make dotenv setup the first thing to run when starting the app. ([@nwalters512](https://github.com/nwalters512) in [#30](https://github.com/illinois/queue/pull/30))
-
 
 ## 20 February 2018
 

--- a/api/courses.js
+++ b/api/courses.js
@@ -84,19 +84,12 @@ router.post(
     check('netid', 'netid must be specified')
       .exists()
       .trim(),
-    check('name')
-      .optional()
-      .trim(),
     failIfErrors,
   ],
   async (req, res, _next) => {
-    const { netid: originalNetid, name } = matchedData(req)
+    const { netid: originalNetid } = matchedData(req)
     const [netid] = originalNetid.split('@')
     const [user] = await User.findOrCreate({ where: { netid } })
-    if (name) {
-      user.name = name
-      await user.save()
-    }
     await user.addStaffAssignment(res.locals.course.id)
     res.status(201).send(user)
   }

--- a/api/courses.js
+++ b/api/courses.js
@@ -81,8 +81,12 @@ router.post(
   [
     requireCourseStaff,
     requireCourse,
-    check('netid', 'netid must be specified').exists(),
-    check('name').optional(),
+    check('netid', 'netid must be specified')
+      .exists()
+      .trim(),
+    check('name')
+      .optional()
+      .trim(),
     failIfErrors,
   ],
   async (req, res, _next) => {

--- a/api/courses.test.js
+++ b/api/courses.test.js
@@ -99,11 +99,12 @@ describe('Courses API', () => {
 
   describe('POST /api/course/:courseId/staff', async () => {
     test('succeeds for admin', async () => {
-      const newUser = { netid: 'newnetid', name: 'New Name' }
+      const newUser = { netid: 'newnetid' }
       const res = await request(app)
         .post('/api/courses/1/staff')
         .send(newUser)
       expect(res.statusCode).toBe(201)
+      expect(res.body.netid).toBe('newnetid')
     })
 
     test('succeeds for course staff', async () => {
@@ -112,6 +113,7 @@ describe('Courses API', () => {
         .post('/api/courses/1/staff?forceuser=225staff')
         .send(newUser)
       expect(res.statusCode).toBe(201)
+      expect(res.body.netid).toBe('newnetid')
     })
 
     test('fails if netid is missing', async () => {

--- a/api/courses.test.js
+++ b/api/courses.test.js
@@ -148,6 +148,18 @@ describe('Courses API', () => {
       expect(user).not.toBe(null)
       expect(user.netid).toBe('newnetid')
     })
+
+    test('trims whitespace from netid', async () => {
+      const newUser = { netid: '  waf     ' }
+      const res = await request(app)
+        .post('/api/courses/1/staff')
+        .send(newUser)
+      expect(res.statusCode).toBe(201)
+      expect(res.body.netid).toBe('waf')
+      const user = await User.findOne({ where: { netid: 'waf' } })
+      expect(user).not.toBe(null)
+      expect(user.netid).toBe('waf')
+    })
   })
 
   describe('DELETE /api/courses/:courseId/staff/:userId', () => {


### PR DESCRIPTION
* Trims whitespace from netids
* Add tests for whitespace trimming
* Remove ability to change user name via the course staff endpoint

Fixes #63