### PR TITLE
README update to reflect the queue as a SaaS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ with the current date and the next changes should go under a **[Next]** header.
 * Add support and tooling for Sequelize database migrations. ([@nwalters512](https://github.com/nwalters512) in [#56](https://github.com/illinois/queue/pull/56))
 * Add confirmation prompt for cancelling and deleting student questions. ([@muakasan](https://github.com/muakasan) in [#71](https://github.com/illinois/queue/pull/71))
 * Hide new question panel for active course staff. ([@genevievehelsel](https://github.com/genevievehelsel) in [#61](https://github.com/illinois/queue/pull/61))
-* Updated README with information about the queue as a service for users at Illinois. ([@wadefagen](https://github.com/wadefagen)
+* Updated README with information about the queue as a service for users at Illinois. ([@wadefagen](https://github.com/wadefagen) in [#73](https://github.com/illinois/queue/pull/73))
 
 ## 13 March 2018
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ with the current date and the next changes should go under a **[Next]** header.
 * Add support and tooling for Sequelize database migrations. ([@nwalters512](https://github.com/nwalters512) in [#56](https://github.com/illinois/queue/pull/56))
 * Add confirmation prompt for cancelling and deleting student questions. ([@muakasan](https://github.com/muakasan) in [#71](https://github.com/illinois/queue/pull/71))
 * Hide new question panel for active course staff. ([@genevievehelsel](https://github.com/genevievehelsel) in [#61](https://github.com/illinois/queue/pull/61))
+* Updated README with information about the queue as a service for users at Illinois. ([@wadefagen](https://github.com/wadefagen)
 
 ## 13 March 2018
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,19 @@
-# queue
+# Illinois Open Source Queue
 [![Build Status](https://travis-ci.org/illinois/queue.svg?branch=master)](https://travis-ci.org/illinois/queue)
+
+A micro-service queue for holding office hours (with shibboleth identity management)
+
+
+## Using the Queue at Illinois
+
+At UIUC, this queue is hosted as a free service by Computer Science and EngrIT.  
+
+- View the queue at https://edu.cs.illinois.edu/queue/ 
+- [Request to have a queue created for your course by filling out this short form](https://forms.illinois.edu/sec/691281)
+
+
+## Running the Queue from Soruce
+
 ### Running locally in `dev` mode:
 - Clone the repository
 - Install [`node` and `npm`](https://nodejs.org/en/download/package-manager/)


### PR DESCRIPTION
A small update to the README to reflect that the queue is a SaaS here at Illinois, with a small webform that e-mails myself, @nwalters512, and @genevievehelsel when submitted.

Closes #23