### PR TITLE
Limit "already answering" check to one queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,7 @@ with the current date and the next changes should go under a **[Next]** header.
 ## [Next]
 
 * Show queue name and location on queue page. ([@sgorse](https://github.com/sgorse) in [#81](https://github.com/illinois/queue/pull/81))
-* Add ability to edit existing queues. ([@zwang180](https://github.com/zwang180) in
-  [#78](https://github.com/illinois/queue/pull/78))
+* Add ability to edit existing queues. ([@zwang180](https://github.com/zwang180) in [#78](https://github.com/illinois/queue/pull/78))
 * Fix [#89](https://github.com/illinois/queue/issues/89) by only checking in one queue for another question being answered by the same user. ([@nwalters512](https://github.com/nwalters512) in [#90](https://github.com/illinois/queue/pull/90))
 
 ## 28 March 2018

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ with the current date and the next changes should go under a **[Next]** header.
 
 * Show queue name and location on queue page. ([@sgorse](https://github.com/sgorse) in [#81](https://github.com/illinois/queue/pull/81))
 * Add ability to edit existing queues. ([@zwang180](https://github.com/zwang180) in
-[#78](https://github.com/illinois/queue/pull/78))
+  [#78](https://github.com/illinois/queue/pull/78))
+* Fix [#89](https://github.com/illinois/queue/issues/89) by only checking in one queue for another question being answered by the same user. ([@nwalters512](https://github.com/nwalters512) in [#90](https://github.com/illinois/queue/pull/90))
 
 ## 28 March 2018
 

--- a/api/questions.js
+++ b/api/questions.js
@@ -110,9 +110,14 @@ router.get(
 // Mark a question as being answered
 router.post(
   '/:questionId/answering',
-  [requireCourseStaffForQueueForQuestion, requireQuestion, failIfErrors],
+  [
+    requireCourseStaffForQueueForQuestion,
+    requireQuestion,
+    requireQueueForQuestion,
+    failIfErrors,
+  ],
   async (req, res, _next) => {
-    const { question } = res.locals
+    const { queue, question } = res.locals
 
     if (question.beingAnswered) {
       // Forbid someone else from taking over this question
@@ -125,11 +130,14 @@ router.post(
       where: {
         answeredById: res.locals.userAuthn.id,
         dequeueTime: null,
+        queueId: queue.id,
       },
     })
 
     if (otherQuestions !== null) {
-      res.status(403).send('You are already answering this question')
+      res
+        .status(403)
+        .send('You are already answering another question on this queue')
       return
     }
 

--- a/api/questions.test.js
+++ b/api/questions.test.js
@@ -255,6 +255,21 @@ describe('Questions API', () => {
       expect(res.body.beingAnswered).toBe(true)
     })
 
+    test('succeeds if user is answering a question on another queue', async () => {
+      // Mark question as being answered by admin
+      const res = await request(app).post(
+        '/api/queues/1/questions/1/answering?forceuser=admin'
+      )
+      expect(res.statusCode).toBe(200)
+      // Attempt to answer as another user
+      const res2 = await request(app).post(
+        '/api/queues/3/questions/3/answering?forceuser=admin'
+      )
+      expect(res2.statusCode).toBe(200)
+      const question = await Question.findById(3)
+      expect(question.answeredById).toBe(2)
+    })
+
     test('fails if another user is already answering the question', async () => {
       // Mark question as being answered by admin
       const res = await request(app).post(


### PR DESCRIPTION
This will allow users to man multiple queues at once, and fixes a bug where a queue was deleted when a user was still answering a question.

Fixes #89 