### PR TITLE
Show dev workshop ad on homepage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ with the current date and the next changes should go under a **[Next]** header.
 
 ## [Next]
 
+* Show dev workshop ad on homepage. ([@nwalters512](https://github.com/nwalters512) in [#107](https://github.com/illinois/queue/pull/107))
+
 ## 18 April 2018
 
 * Fix course shortcode link to work in browsers besides Chrome. ([@nwalters512](https://github.com/nwalters512) in [#101](https://github.com/illinois/queue/pull/101))

--- a/components/DevWorkshopAd.js
+++ b/components/DevWorkshopAd.js
@@ -1,0 +1,26 @@
+import React from 'react'
+import { Alert } from 'reactstrap'
+import moment from 'moment'
+
+export default () => {
+  // Hide ad once the event starts
+  if (moment().isAfter('2018-04-24 19:00:00.000-05')) return null
+
+  return (
+    <Alert color="primary">
+      <h6>Want to work on the queue?</h6>
+      <p className="mb-0">
+        Join us for a development workshop on Thursday, April 24th at 7PM in
+        Siebel 2405. We&apos;ll teach you how to run a version of the queue on
+        your machine, introduce you to the architecture, go over how to
+        contribute, and more!
+        <a
+          className="ml-2"
+          href="https://www.facebook.com/events/352213225287320/"
+        >
+          More information
+        </a>
+      </p>
+    </Alert>
+  )
+}

--- a/components/DevWorkshopAd.js
+++ b/components/DevWorkshopAd.js
@@ -10,7 +10,7 @@ export default () => {
     <Alert color="primary">
       <h6>Want to work on the queue?</h6>
       <p className="mb-0">
-        Join us for a development workshop on Thursday, April 24th at 7PM in
+        Join us for a development workshop on Tuesday, April 24th at 7PM in
         Siebel 2405. We&apos;ll teach you how to run a version of the queue on
         your machine, introduce you to the architecture, go over how to
         contribute, and more!

--- a/pages/index.js
+++ b/pages/index.js
@@ -27,6 +27,7 @@ import NewCourse from '../components/NewCourse'
 import NewQueue from '../components/NewQueue'
 import ShowForAdmin from '../components/ShowForAdmin'
 import QueueCardListContainer from '../containers/QueueCardListContainer'
+import DevWorkshopAd from '../components/DevWorkshopAd'
 
 class Index extends React.Component {
   static async getInitialProps({ store, isServer }) {
@@ -109,6 +110,7 @@ class Index extends React.Component {
     return (
       <Layout>
         <Container>
+          <DevWorkshopAd />
           <div className="d-flex flex-wrap align-items-center mb-4">
             <h1 className="display-4 d-inline-block mb-0 mt-3 mr-auto pr-3">
               Open queues


### PR DESCRIPTION
The ad will automatically be hidden once the workshop starts; we can then rip it out of the code in a later deploy.