### PR TITLE
Making descText and confirmText not required for ConfirmDeleteQueueModel

### DIFF
--- a/src/components/ConfirmModal.js
+++ b/src/components/ConfirmModal.js
@@ -21,8 +21,8 @@ ConfirmModal.propTypes = {
   isOpen: PropTypes.bool.isRequired,
   toggle: PropTypes.func.isRequired,
   confirm: PropTypes.func.isRequired,
-  descText: PropTypes.string.isRequired,
-  confirmText: PropTypes.string.isRequired,
+  descText: PropTypes.string,
+  confirmText: PropTypes.string,
 }
 
 export default ConfirmModal


### PR DESCRIPTION
Fixing issue #79 with @PradyumnaShome and @jrogge