### PR TITLE
Pin the version of node used in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ dist: trusty
 sudo: required
 language: node_js
 node_js:
-  - node
+  - "9.5"
 before_install:
   - wget https://dev.mysql.com/get/mysql-apt-config_0.8.9-1_all.deb
   - sudo dpkg -i mysql-apt-config_0.8.9-1_all.deb


### PR DESCRIPTION
Trying to fix the failing tests in #115 by pinning the version of node used on CI to 9.5.