### PR TITLE
Making descText and confirmText not required for ConfirmDeleteQueueModel

### DIFF
--- a/src/components/ConfirmDeleteQueueModal.js
+++ b/src/components/ConfirmDeleteQueueModal.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import ConfirmModal from './ConfirmModal'
 
 const ConfirmDeleteQueueModal = props => (
@@ -11,6 +12,10 @@ const ConfirmDeleteQueueModal = props => (
   />
 )
 
-ConfirmDeleteQueueModal.propTypes = ConfirmModal.propTypes
+ConfirmDeleteQueueModal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  toggle: PropTypes.func.isRequired,
+  confirm: PropTypes.func.isRequired,
+}
 
 export default ConfirmDeleteQueueModal

--- a/src/components/ConfirmModal.js
+++ b/src/components/ConfirmModal.js
@@ -21,8 +21,8 @@ ConfirmModal.propTypes = {
   isOpen: PropTypes.bool.isRequired,
   toggle: PropTypes.func.isRequired,
   confirm: PropTypes.func.isRequired,
-  descText: PropTypes.string,
-  confirmText: PropTypes.string,
+  descText: PropTypes.string.isRequired,
+  confirmText: PropTypes.string.isRequired,
 }
 
 export default ConfirmModal

--- a/src/components/ConfirmModal.js
+++ b/src/components/ConfirmModal.js
@@ -21,8 +21,8 @@ ConfirmModal.propTypes = {
   isOpen: PropTypes.bool.isRequired,
   toggle: PropTypes.func.isRequired,
   confirm: PropTypes.func.isRequired,
-  descText: PropTypes.string.isRequired,
-  confirmText: PropTypes.string.isRequired,
+  descText: PropTypes.string,
+  confirmText: PropTypes.string,
 }
 
 export default ConfirmModal


### PR DESCRIPTION
Solved with @josh-byster and @jrogge.
Fixes #79.