### PR TITLE
Add fix-lint-js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ with the current date and the next changes should go under a **[Next]** header.
 
 * Reorganize directory structure. ([@nwalters512](https://github.com/nwalters512) in [#108](https://github.com/illinois/queue/pull/108))
 * Remove location from notifications if the queue is a fixed-location queue. ([@redsn0w422](https://github.com/redsn0w422) in [#123](https://github.com/illinois/queue/pull/123))
-* Add `npm run fix-lint-js` ([@redsn0w422](https://github.com/redsn0w422) in [#127](https://github.com/illinois/queue/pull/127))
+* Add `npm run fix-lint-js` to fix linter errors that can be fixed automatically. ([@redsn0w422](https://github.com/redsn0w422) in [#127](https://github.com/illinois/queue/pull/127))
 
 ## 19 April 2018
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ with the current date and the next changes should go under a **[Next]** header.
 
 * Reorganize directory structure. ([@nwalters512](https://github.com/nwalters512) in [#108](https://github.com/illinois/queue/pull/108))
 * Remove location from notifications if the queue is a fixed-location queue. ([@redsn0w422](https://github.com/redsn0w422) in [#123](https://github.com/illinois/queue/pull/123))
+* Add `npm run fix-lint-js` ([@redsn0w422](https://github.com/redsn0w422) in [#127](https://github.com/illinois/queue/pull/127))
 
 ## 19 April 2018
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test": "jest",
     "test-sequential": "jest --runInBand",
     "lint-js": "eslint --ext js .",
+    "fix-lint-js": "eslint --ext js . --fix",
     "prettier": "prettier --write \"src/**/*.js\"",
     "prettier-diff": "prettier --list-different \"src/**/*.js\""
   },


### PR DESCRIPTION
Adds support for running `npm run fix-lint-js`, which passes the `--fix` flag to eslint.

Fixes #125