### PR TITLE
Making descText and confirmText not required for all confirm modals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,9 @@ with the current date and the next changes should go under a **[Next]** header.
 * Reorganize directory structure. ([@nwalters512](https://github.com/nwalters512) in [#108](https://github.com/illinois/queue/pull/108))
 * Remove location from notifications if the queue is a fixed-location queue. ([@redsn0w422](https://github.com/redsn0w422) in [#123](https://github.com/illinois/queue/pull/123))
 * Add `npm run fix-lint-js` to fix linter errors that can be fixed automatically. ([@redsn0w422](https://github.com/redsn0w422) in [#127](https://github.com/illinois/queue/pull/127))
-* Fix confirm modal `PropTypes` to make `descText` and `confirmText` not required. ([@josh-byster](https://github.com/josh-byster), [@PradyumnaShome](https://github.com/PradyumnaShome), and [@jrogge](https://github.com/jrogge) in [#130](https://github.com/illinois/queue/pull/130))
 * Allow a queue to be closed and reopened. ([@genevievehelsel](https://github.com/genevievehelsel) in [#128](https://github.com/illinois/queue/pull/128))
+* Fix confirm modal `PropTypes` to make `descText` and `confirmText` not required. ([@josh-byster](https://github.com/josh-byster), [@PradyumnaShome](https://github.com/PradyumnaShome), and [@jrogge](https://github.com/jrogge) in [#130](https://github.com/illinois/queue/pull/130))
+
 
 ## 19 April 2018
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ with the current date and the next changes should go under a **[Next]** header.
 * Reorganize directory structure. ([@nwalters512](https://github.com/nwalters512) in [#108](https://github.com/illinois/queue/pull/108))
 * Remove location from notifications if the queue is a fixed-location queue. ([@redsn0w422](https://github.com/redsn0w422) in [#123](https://github.com/illinois/queue/pull/123))
 * Add `npm run fix-lint-js` to fix linter errors that can be fixed automatically. ([@redsn0w422](https://github.com/redsn0w422) in [#127](https://github.com/illinois/queue/pull/127))
+* Fixed confirm modal PropTypes to make descText and confirmText not required. ([@josh-byster](https://github.com/josh-byster), [@PradyumnaShome](https://github.com/PradyumnaShome), and [@jrogge](https://github.com/jrogge) in [#130](https://github.com/illinois/queue/pull/130))
 * Allow a queue to be closed and reopened. ([@genevievehelsel](https://github.com/genevievehelsel) in [#128](https://github.com/illinois/queue/pull/128))
 
 ## 19 April 2018

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ with the current date and the next changes should go under a **[Next]** header.
 * Reorganize directory structure. ([@nwalters512](https://github.com/nwalters512) in [#108](https://github.com/illinois/queue/pull/108))
 * Remove location from notifications if the queue is a fixed-location queue. ([@redsn0w422](https://github.com/redsn0w422) in [#123](https://github.com/illinois/queue/pull/123))
 * Add `npm run fix-lint-js` to fix linter errors that can be fixed automatically. ([@redsn0w422](https://github.com/redsn0w422) in [#127](https://github.com/illinois/queue/pull/127))
-* Fixed confirm modal PropTypes to make descText and confirmText not required. ([@josh-byster](https://github.com/josh-byster), [@PradyumnaShome](https://github.com/PradyumnaShome), and [@jrogge](https://github.com/jrogge) in [#130](https://github.com/illinois/queue/pull/130))
+* Fix confirm modal `PropTypes` to make `descText` and `confirmText` not required. ([@josh-byster](https://github.com/josh-byster), [@PradyumnaShome](https://github.com/PradyumnaShome), and [@jrogge](https://github.com/jrogge) in [#130](https://github.com/illinois/queue/pull/130))
 * Allow a queue to be closed and reopened. ([@genevievehelsel](https://github.com/genevievehelsel) in [#128](https://github.com/illinois/queue/pull/128))
 
 ## 19 April 2018

--- a/src/components/ConfirmCancelQuestionModal.js
+++ b/src/components/ConfirmCancelQuestionModal.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import ConfirmModal from './ConfirmModal'
 
 const ConfirmCancelQuestionModal = props => (
@@ -11,6 +12,10 @@ const ConfirmCancelQuestionModal = props => (
   />
 )
 
-ConfirmCancelQuestionModal.propTypes = ConfirmModal.propTypes
+ConfirmCancelQuestionModal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  toggle: PropTypes.func.isRequired,
+  confirm: PropTypes.func.isRequired,
+}
 
 export default ConfirmCancelQuestionModal

--- a/src/components/ConfirmDeleteQuestionModal.js
+++ b/src/components/ConfirmDeleteQuestionModal.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import ConfirmModal from './ConfirmModal'
 
 const ConfirmDeleteQuestionModal = props => (
@@ -11,6 +12,10 @@ const ConfirmDeleteQuestionModal = props => (
   />
 )
 
-ConfirmDeleteQuestionModal.propTypes = ConfirmModal.propTypes
+ConfirmDeleteQuestionModal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  toggle: PropTypes.func.isRequired,
+  confirm: PropTypes.func.isRequired,
+}
 
 export default ConfirmDeleteQuestionModal

--- a/src/components/ConfirmDeleteQueueModal.js
+++ b/src/components/ConfirmDeleteQueueModal.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import ConfirmModal from './ConfirmModal'
 
 const ConfirmDeleteQueueModal = props => (
@@ -11,6 +12,10 @@ const ConfirmDeleteQueueModal = props => (
   />
 )
 
-ConfirmDeleteQueueModal.propTypes = ConfirmModal.propTypes
+ConfirmDeleteQueueModal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  toggle: PropTypes.func.isRequired,
+  confirm: PropTypes.func.isRequired,
+}
 
 export default ConfirmDeleteQueueModal

--- a/src/components/ConfirmLeaveQueueModal.js
+++ b/src/components/ConfirmLeaveQueueModal.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import ConfirmModal from './ConfirmModal'
 
 const ConfirmLeaveQueueModal = props => (
@@ -11,6 +12,10 @@ const ConfirmLeaveQueueModal = props => (
   />
 )
 
-ConfirmLeaveQueueModal.propTypes = ConfirmModal.propTypes
+ConfirmLeaveQueueModal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  toggle: PropTypes.func.isRequired,
+  confirm: PropTypes.func.isRequired,
+}
 
 export default ConfirmLeaveQueueModal

--- a/src/components/ConfirmModal.js
+++ b/src/components/ConfirmModal.js
@@ -21,8 +21,8 @@ ConfirmModal.propTypes = {
   isOpen: PropTypes.bool.isRequired,
   toggle: PropTypes.func.isRequired,
   confirm: PropTypes.func.isRequired,
-  descText: PropTypes.string,
-  confirmText: PropTypes.string,
+  descText: PropTypes.string.isRequired,
+  confirmText: PropTypes.string.isRequired,
 }
 
 export default ConfirmModal

--- a/src/components/ConfirmModal.js
+++ b/src/components/ConfirmModal.js
@@ -21,8 +21,8 @@ ConfirmModal.propTypes = {
   isOpen: PropTypes.bool.isRequired,
   toggle: PropTypes.func.isRequired,
   confirm: PropTypes.func.isRequired,
-  descText: PropTypes.string.isRequired,
-  confirmText: PropTypes.string.isRequired,
+  descText: PropTypes.string,
+  confirmText: PropTypes.string,
 }
 
 export default ConfirmModal


### PR DESCRIPTION
Fixed alongside @PradyumnaShome and @jrogge.

Fixes #79 and issue in #121.
