### PR TITLE
Fix bug on course page with queues shown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@ with the current date and the next changes should go under a **[Next]** header.
 
 ## [Next]
 
-* Fix bug on course page with queues shown. ([@genevievehelsel](https://github.com/genevievehelsel) in [#145](https://github.com/illinois/queue/pull/145))
 * Add open and closed cards to course pages. ([@genevievehelsel](https://github.com/genevievehelsel) in [#142](https://github.com/illinois/queue/pull/142))
 * Upgrade to Next 7 and React 16.5.2. ([@nwalters512](https://github.com/nwalters512) in [#143](https://github.com/illinois/queue/pull/143))
 * Sort queues and courses by name. ([@genevievehelsel](https://github.com/genevievehelsel) in [#144](https://github.com/illinois/queue/pull/144))
+* Fix bug on course page with queues shown. ([@genevievehelsel](https://github.com/genevievehelsel) in [#145](https://github.com/illinois/queue/pull/145))
 
 ## 5 September 2018
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ with the current date and the next changes should go under a **[Next]** header.
 
 ## [Next]
 
+* Fix bug on course page with queues shown. ([@genevievehelsel](https://github.com/genevievehelsel) in [#145](https://github.com/illinois/queue/pull/145))
 * Add open and closed cards to course pages. ([@genevievehelsel](https://github.com/genevievehelsel) in [#142](https://github.com/illinois/queue/pull/142))
 * Upgrade to Next 7 and React 16.5.2. ([@nwalters512](https://github.com/nwalters512) in [#143](https://github.com/illinois/queue/pull/143))
 

--- a/src/pages/course.js
+++ b/src/pages/course.js
@@ -71,9 +71,11 @@ class Course extends React.Component {
 
     const openQueueIds = this.props.queues
       .filter(queue => queue.open)
+      .filter(queue => queue.courseId === this.props.courseId)
       .map(queue => queue.id)
     const closedQueueIds = this.props.queues
       .filter(queue => !queue.open)
+      .filter(queue => queue.courseId === this.props.courseId)
       .map(queue => queue.id)
 
     return (
@@ -171,6 +173,7 @@ Course.propTypes = {
       name: PropTypes.string,
       location: PropTypes.location,
       open: PropTypes.boolean,
+      courseId: PropTypes.number,
     })
   ),
   isFetching: PropTypes.bool,


### PR DESCRIPTION
I discovered that my last pr started showing all the queues on each course page, added a filter to only show queues with the correct course id.