### PR TITLE
Remove message code from prototyping phase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ with the current date and the next changes should go under a **[Next]** header.
 ## [Next]
 
 * Fix queues and course sorting. ([@genevievehelsel](https://github.com/genevievehelsel) in [#150](https://github.com/illinois/queue/pull/150))
+* Remove message code from API prototyping phase. ([@nwalters512](https://github.com/nwalters512) in [#151](https://github.com/illinois/queue/pull/151))
 
 ## 10 October 2018
 

--- a/src/components/QueueStatusToggle.js
+++ b/src/components/QueueStatusToggle.js
@@ -7,7 +7,6 @@ class QueueStatusToggle extends React.Component {
   toggleQueueStatus() {
     const attributes = {
       open: !this.props.queue.open,
-      message: this.props.queue.open ? 'Closed' : 'Open',
     }
     this.props.updateQueue(this.props.queue.id, attributes)
   }


### PR DESCRIPTION
I was using this to test the message API while building it, but obviously we don't want this anymore.