### PR TITLE
Log errors to stderr instead of stdout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ with the current date and the next changes should go under a **[Next]** header.
 
 ## [Next]
 
+* Log errors to `stdout` instead of `stderr`. ([@nwalters512](https://github.com/nwalters512) in [#152](https://github.com/illinois/queue/pull/152))
+
 ## 11 October 2018
 
 * Fix queues and course sorting. ([@genevievehelsel](https://github.com/genevievehelsel) in [#150](https://github.com/illinois/queue/pull/150))

--- a/src/util/logger.js
+++ b/src/util/logger.js
@@ -9,7 +9,9 @@ module.exports = createLogger({
     align(),
     printf(info => `${info.timestamp} [${info.level}]: ${info.message}`)
   ),
-  transports: [new transports.Console({
-    stderrLevels: ['error'],
-  })],
+  transports: [
+    new transports.Console({
+      stderrLevels: ['error'],
+    }),
+  ],
 })

--- a/src/util/logger.js
+++ b/src/util/logger.js
@@ -9,5 +9,7 @@ module.exports = createLogger({
     align(),
     printf(info => `${info.timestamp} [${info.level}]: ${info.message}`)
   ),
-  transports: [new transports.Console()],
+  transports: [new transports.Console({
+    stderrLevels: ['error'],
+  })],
 })


### PR DESCRIPTION
This way, errors will properly show up in our ops slack channel.