### PR TITLE
Remove slash from the index route

### DIFF
--- a/src/routes.js
+++ b/src/routes.js
@@ -2,7 +2,7 @@ const routes = require('next-routes')()
 const { withBaseUrl } = require('./util')
 
 routes
-  .add('index', withBaseUrl('/'))
+  .add('index', withBaseUrl(''))
   .add('queue', withBaseUrl('/queue/:id'))
   .add('createCourse', withBaseUrl('/course/create'))
   .add('course', withBaseUrl('/course/:id'))


### PR DESCRIPTION
When the base url isn't empty (for instance, `foo`), `/foo` couldn't be resolved but `/foo/` could be. This removes the trailing slash from the index route so that both routes work.