### PR TITLE
Fix index route with empty base URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ with the current date and the next changes should go under a **[Next]** header.
 
 ## [Next]
 
+* Fix index route with empty base URL. ([@nwalters512](https://github.com/nwalters512) in [#160](https://github.com/illinois/queue/pull/160))
+
 ## 22 October 2018
 
 * Log errors to `stdout` instead of `stderr`. ([@nwalters512](https://github.com/nwalters512) in [#152](https://github.com/illinois/queue/pull/152))

--- a/src/routes.js
+++ b/src/routes.js
@@ -1,9 +1,16 @@
 const routes = require('next-routes')()
-const { withBaseUrl } = require('./util')
+const { baseUrl, withBaseUrl } = require('./util')
 
-routes
-  .add('index', withBaseUrl(''))
-  .add('queue', withBaseUrl('/queue/:id'))
+// We need to special-case the index route. When running with a non-empty
+// base URL, for instance /foo, we'll fail to resolve /foo if the index URL 
+// ends with a slash. However, when running locally with an empty base URL,
+// we need the root route to be "/" for it to be resolved properly.
+if (baseUrl === '') {
+  routes.add('index', '/')
+} else {
+  routes.add('index', withBaseUrl('/'))
+}
+routes.add('queue', withBaseUrl('/queue/:id'))
   .add('createCourse', withBaseUrl('/course/create'))
   .add('course', withBaseUrl('/course/:id'))
   .add('courseStaff', withBaseUrl('/course/:id/staff'))

--- a/src/routes.js
+++ b/src/routes.js
@@ -8,7 +8,7 @@ const { baseUrl, withBaseUrl } = require('./util')
 if (baseUrl === '') {
   routes.add('index', '/')
 } else {
-  routes.add('index', withBaseUrl('/'))
+  routes.add('index', withBaseUrl(''))
 }
 routes
   .add('queue', withBaseUrl('/queue/:id'))

--- a/src/routes.js
+++ b/src/routes.js
@@ -2,7 +2,7 @@ const routes = require('next-routes')()
 const { baseUrl, withBaseUrl } = require('./util')
 
 // We need to special-case the index route. When running with a non-empty
-// base URL, for instance /foo, we'll fail to resolve /foo if the index URL 
+// base URL, for instance /foo, we'll fail to resolve /foo if the index URL
 // ends with a slash. However, when running locally with an empty base URL,
 // we need the root route to be "/" for it to be resolved properly.
 if (baseUrl === '') {
@@ -10,7 +10,8 @@ if (baseUrl === '') {
 } else {
   routes.add('index', withBaseUrl('/'))
 }
-routes.add('queue', withBaseUrl('/queue/:id'))
+routes
+  .add('queue', withBaseUrl('/queue/:id'))
   .add('createCourse', withBaseUrl('/course/create'))
   .add('course', withBaseUrl('/course/:id'))
   .add('courseStaff', withBaseUrl('/course/:id/staff'))


### PR DESCRIPTION
#158 introduced an accidental bug when running with an empty base URL. This PR special-cases the root path to include a trailing slash when no base URL is set.