### PR TITLE
Bolden course names on queue cards

### DIFF
--- a/src/components/QueueCard.js
+++ b/src/components/QueueCard.js
@@ -45,7 +45,7 @@ const QueueCard = ({
       {...rest}
     >
       <CardBody>
-        <CardTitle className="d-flex flex-wrap align-items-center">
+        <CardTitle tag="h5" className="d-flex flex-wrap align-items-center">
           <span className="mb-2 mr-auto pr-3">{title}</span>
           <div>
             <ShowForCourseStaff courseId={queue.courseId}>


### PR DESCRIPTION
`reactstrap` 7.0.0 changed the default `CardTitle` tag to be `div` instead of `h5` which introduced a regression.

See https://github.com/reactstrap/reactstrap/pull/1298

Closes #177.