### PR TITLE
Specify deleted queue

### DIFF
--- a/src/components/ConfirmDeleteQueueModal.js
+++ b/src/components/ConfirmDeleteQueueModal.js
@@ -12,7 +12,7 @@ const ConfirmDeleteQueueModal = props => {
       isOpen={props.isOpen}
       toggle={props.toggle}
       confirm={props.confirm}
-      descText={`${fullName} and all its open questions will be deleted. This cannot be undone`}
+      descText={`${fullName} and all its open questions will be deleted. This cannot be undone.`}
       confirmText="Delete queue"
     />
   )

--- a/src/components/ConfirmDeleteQueueModal.js
+++ b/src/components/ConfirmDeleteQueueModal.js
@@ -2,20 +2,33 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import ConfirmModal from './ConfirmModal'
 
-const ConfirmDeleteQueueModal = props => (
-  <ConfirmModal
-    isOpen={props.isOpen}
-    toggle={props.toggle}
-    confirm={props.confirm}
-    descText="This queue and all its open questions will be deleted."
-    confirmText="Delete queue"
-  />
-)
+const ConfirmDeleteQueueModal = props => {
+  const fullName =
+    props.queueName && props.courseName
+      ? `${props.courseName} ${props.queueName}`
+      : 'This queue'
+  return (
+    <ConfirmModal
+      isOpen={props.isOpen}
+      toggle={props.toggle}
+      confirm={props.confirm}
+      descText={`${fullName} and all its open questions will be deleted. This cannot be undone`}
+      confirmText="Delete queue"
+    />
+  )
+}
 
 ConfirmDeleteQueueModal.propTypes = {
   isOpen: PropTypes.bool.isRequired,
   toggle: PropTypes.func.isRequired,
   confirm: PropTypes.func.isRequired,
+  queueName: PropTypes.string,
+  courseName: PropTypes.string,
+}
+
+ConfirmDeleteQueueModal.defaultProps = {
+  queueName: null,
+  courseName: null,
 }
 
 export default ConfirmDeleteQueueModal

--- a/src/components/QueueCardList.js
+++ b/src/components/QueueCardList.js
@@ -148,6 +148,16 @@ class QueueCardList extends React.Component {
       <Fragment>
         {queues}
         <ConfirmDeleteQueueModal
+          queueName={
+            this.state.pendingDeleteQueue
+              ? this.props.queues[this.state.pendingDeleteQueue.queueId].name
+              : null
+          }
+          courseName={
+            this.state.pendingDeleteQueue
+              ? this.props.courses[this.state.pendingDeleteQueue.courseId].name
+              : null
+          }
           isOpen={this.state.showDeleteQueueModal}
           toggle={() => this.toggleDeleteModal()}
           confirm={() => this.confirmDeleteQueue()}


### PR DESCRIPTION
The course and queue name are now being used in `ConfirmDeleteQueueModal` to specify which queue is currently pending deletion.

Closes #174.