### PR TITLE
Tab through queues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ with the current date and the next changes should go under a **[Next]** header.
 
 ## [Next]
 
-* Allow user to select queues by tabbing through the main page. ([@shwavedefapp](https://github.com/shwavedefapp))
+* Allow user to select queues by tabbing through the main page. ([@shwavedefapp](https://github.com/shwavedefapp) in [#192](https://github.com/illinois/queue/pull/192))
 
 ## 26 January 2019
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ with the current date and the next changes should go under a **[Next]** header.
 
 ## [Next]
 
+* Allow user to select queues by tabbing through the main page. ([@shwavedefapp](https://github.com/shwavedefapp))
+
 ## 26 January 2019
 
 * Fix regression where course names in `QueueCard`s would not be bold. ([@james9909](https://github.com/james9909) in [#178](https://github.com/illinois/queue/pull/178))

--- a/src/components/QueueCard.js
+++ b/src/components/QueueCard.js
@@ -36,6 +36,10 @@ const QueueCard = ({
     onUpdate()
   }
 
+  const preventKeyBubbleUp = e => {
+    e.stopPropagation()
+  }
+
   const title = courseName || queueName
   const showQueueNameInBody = !!courseName
 
@@ -49,7 +53,13 @@ const QueueCard = ({
           <span className="h5 mb-2 mr-auto pr-3">{title}</span>
           <div>
             <ShowForCourseStaff courseId={queue.courseId}>
-              <Button color="danger" size="sm" outline onClick={handleDelete}>
+              <Button
+                color="danger"
+                size="sm"
+                outline
+                onClick={handleDelete}
+                onKeyPress={preventKeyBubbleUp}
+              >
                 Delete
               </Button>
             </ShowForCourseStaff>
@@ -60,6 +70,7 @@ const QueueCard = ({
                 className="mr-0 ml-1"
                 outline
                 onClick={handleUpdate}
+                onKeyPress={preventKeyBubbleUp}
               >
                 Edit
               </Button>

--- a/src/components/QueueCardList.js
+++ b/src/components/QueueCardList.js
@@ -114,7 +114,7 @@ class QueueCardList extends React.Component {
       }
 
       const handleQueueKeyPress = (e, id) => {
-        if (e.key == 'Enter' || e.key == ' ') {
+        if (e.key === 'Enter' || e.key === ' ') {
           handleQueueClick(id)
         }
       }

--- a/src/components/QueueCardList.js
+++ b/src/components/QueueCardList.js
@@ -113,6 +113,12 @@ class QueueCardList extends React.Component {
         Router.pushRoute('queue', { id })
       }
 
+      const handleQueueKeyPress = (e, id) => {
+        if (e.key == 'Enter' || e.key == ' ') {
+          handleQueueClick(id)
+        }
+      }
+
       this.props.queueIds.sort(this.queueSorter.bind(this))
 
       queues = this.props.queueIds.map(queueId => {
@@ -127,6 +133,8 @@ class QueueCardList extends React.Component {
               onClick={() => handleQueueClick(queue.id)}
               onDelete={() => this.deleteQueue(queue.courseId, queue.id)}
               onUpdate={() => this.editQueue(queue.id)}
+              onKeyPress={e => handleQueueKeyPress(e, queue.id)}
+              tabIndex="0"
             />
           </CardCol>
         )


### PR DESCRIPTION
Allows tabbing through a `QueueCardList` and selecting with _Enter_ or _Spacebar_. Prevents the Edit and Delete buttons from propagating keypresses to the `QueueCard`.