### PR TITLE
Fix page crash after deleting a queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ with the current date and the next changes should go under a **[Next]** header.
 
 * Update all dependencies. ([@nwalters512](https://github.com/nwalters512) in [#206](https://github.com/illinois/queue/pull/206))
 * Implement landing url redirects. ([@james9909](https://github.com/james9909) in [#208](https://github.com/illinois/queue/pull/208))
+* Fix page crash after deleting a queue. ([@james9909](https://github.com/james9909) in [#209](https://github.com/illinois/queue/pull/209))
 
 ## 8 February 2019
 

--- a/src/components/QueueCardList.js
+++ b/src/components/QueueCardList.js
@@ -152,18 +152,20 @@ class QueueCardList extends React.Component {
       )
     }
 
+    const { pendingDeleteQueue } = this.state
     return (
       <Fragment>
         {queues}
         <ConfirmDeleteQueueModal
           queueName={
-            this.state.pendingDeleteQueue
-              ? this.props.queues[this.state.pendingDeleteQueue.queueId].name
+            pendingDeleteQueue && this.props.queues[pendingDeleteQueue.queueId]
+              ? this.props.queues[pendingDeleteQueue.queueId].name
               : null
           }
           courseName={
-            this.state.pendingDeleteQueue
-              ? this.props.courses[this.state.pendingDeleteQueue.courseId].name
+            pendingDeleteQueue &&
+            this.props.courses[pendingDeleteQueue.courseId]
+              ? this.props.courses[pendingDeleteQueue.courseId].name
               : null
           }
           isOpen={this.state.showDeleteQueueModal}


### PR DESCRIPTION
Fixes a crash caused by `pendingDeleteQueue` not being set to null before `QueueCardList` re-renders.