### PR TITLE
Validate queue when sending notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ with the current date and the next changes should go under a **[Next]** header.
 
 ## [Next]
 * Add user-facing error messages. ([@james9909](https://github.com/james9909) in [#195](https://github.com/illinois/queue/pull/195))
+* Validate queue when sending notifications to course staff. ([@james9909](https://github.com/james9909) in [#222](https://github.com/illinois/queue/pull/222))
 
 ## 19 February 2019
 

--- a/src/redux/questionNotificationMiddleware.js
+++ b/src/redux/questionNotificationMiddleware.js
@@ -40,9 +40,11 @@ function closeNotification(queueId, questionId) {
   delete notifications[queueId][questionId]
 }
 
-function isOnDutyStaff(activeStaff, user) {
+function isOnDutyStaff(activeStaff, user, queueId) {
   return Object.keys(activeStaff).some(
-    key => activeStaff[key].userId === user.id
+    key =>
+      activeStaff[key].userId === user.id &&
+      activeStaff[key].queueId === queueId
   )
 }
 
@@ -54,10 +56,10 @@ export default store => next => action => {
   if (action.type === CREATE_QUESTION.SUCCESS) {
     const { activeStaff } = state.activeStaff
     // On duty staff cannot ask questions, so no need to filter by askedById
-    if (isOnDutyStaff(activeStaff, user)) {
+    const { id, name, location, queueId } = action.question
+    const queue = state.queues.queues[queueId]
+    if (isOnDutyStaff(activeStaff, user, queueId)) {
       const title = 'New question'
-      const { id, name, location, queueId } = action.question
-      const queue = state.queues.queues[queueId]
       let body = ''
 
       if (queue.fixedLocation) {
@@ -78,7 +80,7 @@ export default store => next => action => {
   } else if (action.type === UPDATE_QUESTION.SUCCESS) {
     const { question } = action
     const { activeStaff } = state.activeStaff
-    if (isOnDutyStaff(activeStaff, user)) {
+    if (isOnDutyStaff(activeStaff, user, question.queueId)) {
       // Close question creation notification
       closeNotification(question.queueId, question.id)
     }


### PR DESCRIPTION
Adds additional validation to make sure that active staff only receive relevant "New Question" notifications.

It might also be worth noting that active staff will not receive notifications for the queue they're staffing while browsing another queue unless they also have another tab open. This is a side-effect of when we decide to unsubscribe from queue socket events. 

Closes #203.