### PR TITLE
Hide confidential queue information over API and websockets

### DIFF
--- a/doc/Auth.md
+++ b/doc/Auth.md
@@ -3,9 +3,9 @@
 The Queue uses Shibboleth to authenticate users. However, we don't do Shib
 authentication on every request, for a couple of reasons:
 
-* Websockets don't end up with Shibboleth authentication/identity headers,
+- Websockets don't end up with Shibboleth authentication/identity headers,
   which we'll need for private queues
-* Shibboleth is configured with policies that enforce reauthentication
+- Shibboleth is configured with policies that enforce reauthentication
   whenever the user changes networks, and also every 24 hours. With 2FA
   on the way, this will become increasingly annoying
 
@@ -14,3 +14,13 @@ identity. We then establish our own "session" for them using a JSON Web
 Token. When that token expires, we re-authenticate using Shibboleth. This
 also allows us to use other forms of authentication, such as OAuth. In
 all cases, we simply issue a JWT that identifies the user to us.
+
+# Authorization
+
+Every API request goes through the authorization middleware defined in
+`src/middleware/authz.js`. That middleware attaches authorization information
+to `res.locals.userAuthz`:
+
+- `res.locals.userAuthz.isAdmin`: If the current user is a global admin
+- `res.locals.userAuthz.staffedCourseIds`: A list of all course IDs that the current
+  user is on staff for

--- a/src/api/questions.js
+++ b/src/api/questions.js
@@ -132,8 +132,10 @@ router.get(
       question.get({ plain: true })
     )
     if (isConfidential) {
-      if (!canUserSeeQuestionDetailsForConfidentialQueue(res, courseId)) {
-        questions = filterConfidentialQueueQuestionsForUser(res, questions)
+      const { userAuthz } = res.locals
+      if (!canUserSeeQuestionDetailsForConfidentialQueue(userAuthz, courseId)) {
+        const { id: userId } = res.locals.userAuthn
+        questions = filterConfidentialQueueQuestionsForUser(userId, questions)
       }
     }
 
@@ -146,9 +148,10 @@ router.get(
   [requireQuestion, requireQueueForQuestion, failIfErrors],
   (req, res, _next) => {
     const { courseId, isConfidential } = res.locals.queue
-    const { id: userId } = res.locals.userAuthn
     if (isConfidential) {
-      if (!canUserSeeQuestionDetailsForConfidentialQueue(res, courseId)) {
+      const { id: userId } = res.locals.userAuthn
+      const { userAuthz } = res.locals
+      if (!canUserSeeQuestionDetailsForConfidentialQueue(userAuthz, courseId)) {
         if (res.locals.question.askedById !== userId) {
           res.status(403).send('You are not authorized to access that question')
           return

--- a/src/api/queues.js
+++ b/src/api/queues.js
@@ -115,9 +115,16 @@ router.get(
     // If this is a confidential queue, don't send any actual question data
     // back to the client, besides IDs
     if (queue.isConfidential) {
-      if (!canUserSeeQuestionDetailsForConfidentialQueue(res, queue.courseId)) {
+      const { userAuthz } = res.locals
+      if (
+        !canUserSeeQuestionDetailsForConfidentialQueue(
+          userAuthz,
+          queue.courseId
+        )
+      ) {
+        const { id: userId } = res.locals.userAuthn
         const filtered = filterConfidentialQueueQuestionsForUser(
-          res,
+          userId,
           queue.questions
         )
         queue.questions = filtered

--- a/src/api/queues.test.js
+++ b/src/api/queues.test.js
@@ -86,7 +86,7 @@ describe('Queues API', () => {
     })
   })
 
-  describe('GET /api/queues/5', () => {
+  describe('GET /api/queues/5 (confidential queue)', () => {
     test('includes all question data for admins', async () => {
       const request = await requestAsUser(app, 'admin')
       const res = await request.get('/api/queues/5')

--- a/src/api/queues.test.js
+++ b/src/api/queues.test.js
@@ -87,8 +87,8 @@ describe('Queues API', () => {
   })
 
   describe('GET /api/queues/5 (confidential queue)', () => {
-    test('includes all question data for admins', async () => {
-      const request = await requestAsUser(app, 'admin')
+    const includesDataForUser = async user => {
+      const request = await requestAsUser(app, user)
       const res = await request.get('/api/queues/5')
 
       expect(Array.isArray(res.body.questions)).toBeTruthy()
@@ -98,10 +98,18 @@ describe('Queues API', () => {
       expect(question1).toHaveProperty('askedBy.netid', 'student')
       expect(question2).toHaveProperty('askedById', 6)
       expect(question2).toHaveProperty('askedBy.netid', 'otherstudent')
+    }
+
+    test('includes all question data for admin', async () => {
+      await includesDataForUser('admin')
     })
 
-    test('excludes question data for students on confidential queue', async () => {
-      const request = await requestAsUser(app, 'student')
+    test('includes all question data for course staff', async () => {
+      await includesDataForUser('225staff')
+    })
+
+    const excludesDataForUser = async user => {
+      const request = await requestAsUser(app, user)
       const res = await request.get('/api/queues/5')
 
       // We expect all questions not asked by 'student' (user 5) to have no
@@ -115,6 +123,14 @@ describe('Queues API', () => {
           expect(Object.keys(question)).toEqual(['id'])
         }
       })
+    }
+
+    test('excludes question data for other course staff on confidential queue', async () => {
+      await excludesDataForUser('241staff')
+    })
+
+    test('excludes question data for students on confidential queue', async () => {
+      await excludesDataForUser('student')
     })
   })
 

--- a/src/api/util.js
+++ b/src/api/util.js
@@ -58,8 +58,8 @@ const requireModelForModel = (
   }
 }
 
-const canUserSeeQuestionDetailsForConfidentialQueue = (res, courseId) => {
-  const { isAdmin, staffedCourseIds } = res.locals.userAuthz
+const canUserSeeQuestionDetailsForConfidentialQueue = (userAuthz, courseId) => {
+  const { isAdmin, staffedCourseIds } = userAuthz
   const staffsQueue = staffedCourseIds.findIndex(id => id === courseId) !== -1
   return isAdmin || staffsQueue
 }
@@ -71,8 +71,7 @@ const canUserSeeQuestionDetailsForConfidentialQueue = (res, courseId) => {
  * @param {Response} res The response containing user info on res.locals
  * @param {Questions[]} questions The list of questions to remove sensitive info from
  */
-const filterConfidentialQueueQuestionsForUser = (res, questions) => {
-  const { id: userId } = res.locals.userAuthn
+const filterConfidentialQueueQuestionsForUser = (userId, questions) => {
   return questions.map(question => {
     if (question.askedById === userId) {
       return question

--- a/src/api/util.js
+++ b/src/api/util.js
@@ -58,6 +58,29 @@ const requireModelForModel = (
   }
 }
 
+const canUserSeeQuestionDetailsForConfidentialQueue = (res, courseId) => {
+  const { isAdmin, staffedCourseIds } = res.locals.userAuthz
+  const staffsQueue = staffedCourseIds.findIndex(id => id === courseId) !== -1
+  return isAdmin || staffsQueue
+}
+
+/**
+ * Removes any sensitive user information from all questions not asked by the
+ * user making this request.
+ *
+ * @param {Response} res The response containing user info on res.locals
+ * @param {Questions[]} questions The list of questions to remove sensitive info from
+ */
+const filterConfidentialQueueQuestionsForUser = (res, questions) => {
+  const { id: userId } = res.locals.userAuthn
+  return questions.map(question => {
+    if (question.askedById === userId) {
+      return question
+    }
+    return { id: question.id }
+  })
+}
+
 module.exports = {
   failIfErrors(req, res, next) {
     const errors = validationResult(req)
@@ -83,4 +106,8 @@ module.exports = {
   // These have to be exported for testing
   findPropertyInRequest,
   requireModel,
+
+  // Stuff for confidential queues
+  canUserSeeQuestionDetailsForConfidentialQueue,
+  filterConfidentialQueueQuestionsForUser,
 }

--- a/src/api/util.test.js
+++ b/src/api/util.test.js
@@ -125,4 +125,82 @@ describe('Testing Utils', () => {
       expect(send).toBeCalled()
     })
   })
+
+  describe('canUserSeeQuestionDetailsForConfidentialQueue', () => {
+    test('returns true for an admin', () => {
+      const res = {
+        locals: {
+          userAuthz: {
+            isAdmin: true,
+            staffedCourseIds: [],
+          },
+        },
+      }
+      const value = util.canUserSeeQuestionDetailsForConfidentialQueue(res, 123)
+      expect(value).toBeTruthy()
+    })
+
+    test('returns true for course staff', () => {
+      const res = {
+        locals: {
+          userAuthz: {
+            isAdmin: false,
+            staffedCourseIds: [123],
+          },
+        },
+      }
+      const value = util.canUserSeeQuestionDetailsForConfidentialQueue(res, 123)
+      expect(value).toBeTruthy()
+    })
+
+    test('returns false for non-admin, non-course staff', () => {
+      const res = {
+        locals: {
+          userAuthz: {
+            isAdmin: false,
+            staffedCourseIds: [],
+          },
+        },
+      }
+      const value = util.canUserSeeQuestionDetailsForConfidentialQueue(res, 123)
+      expect(value).toBeFalsy()
+    })
+  })
+
+  describe('filterConfidentialQueueQuestionsForUser', () => {
+    test('removes question info from other users', () => {
+      const res = {
+        locals: {
+          userAuthn: {
+            id: 123,
+          },
+        },
+      }
+      const questions = [
+        {
+          id: 10,
+          askedById: 321,
+          name: 'Secret',
+        },
+        {
+          id: 11,
+          askedById: 123,
+          name: 'Not a Secret',
+        },
+        {
+          id: 12,
+          askedById: 456,
+          name: 'Also a Secret',
+        },
+      ]
+      const result = util.filterConfidentialQueueQuestionsForUser(
+        res,
+        questions
+      )
+      expect(result).toHaveLength(3)
+      expect(result[0]).toEqual({ id: 10 })
+      expect(result[1]).toEqual(questions[1])
+      expect(result[2]).toEqual({ id: 12 })
+    })
+  })
 })

--- a/src/api/util.test.js
+++ b/src/api/util.test.js
@@ -128,54 +128,44 @@ describe('Testing Utils', () => {
 
   describe('canUserSeeQuestionDetailsForConfidentialQueue', () => {
     test('returns true for an admin', () => {
-      const res = {
-        locals: {
-          userAuthz: {
-            isAdmin: true,
-            staffedCourseIds: [],
-          },
-        },
+      const userAuthz = {
+        isAdmin: true,
+        staffedCourseIds: [],
       }
-      const value = util.canUserSeeQuestionDetailsForConfidentialQueue(res, 123)
+      const value = util.canUserSeeQuestionDetailsForConfidentialQueue(
+        userAuthz,
+        123
+      )
       expect(value).toBeTruthy()
     })
 
     test('returns true for course staff', () => {
-      const res = {
-        locals: {
-          userAuthz: {
-            isAdmin: false,
-            staffedCourseIds: [123],
-          },
-        },
+      const userAuthz = {
+        isAdmin: false,
+        staffedCourseIds: [123],
       }
-      const value = util.canUserSeeQuestionDetailsForConfidentialQueue(res, 123)
+      const value = util.canUserSeeQuestionDetailsForConfidentialQueue(
+        userAuthz,
+        123
+      )
       expect(value).toBeTruthy()
     })
 
     test('returns false for non-admin, non-course staff', () => {
-      const res = {
-        locals: {
-          userAuthz: {
-            isAdmin: false,
-            staffedCourseIds: [],
-          },
-        },
+      const userAuthz = {
+        isAdmin: false,
+        staffedCourseIds: [],
       }
-      const value = util.canUserSeeQuestionDetailsForConfidentialQueue(res, 123)
+      const value = util.canUserSeeQuestionDetailsForConfidentialQueue(
+        userAuthz,
+        123
+      )
       expect(value).toBeFalsy()
     })
   })
 
   describe('filterConfidentialQueueQuestionsForUser', () => {
     test('removes question info from other users', () => {
-      const res = {
-        locals: {
-          userAuthn: {
-            id: 123,
-          },
-        },
-      }
       const questions = [
         {
           id: 10,
@@ -194,7 +184,7 @@ describe('Testing Utils', () => {
         },
       ]
       const result = util.filterConfidentialQueueQuestionsForUser(
-        res,
+        123,
         questions
       )
       expect(result).toHaveLength(3)

--- a/src/middleware/authz.js
+++ b/src/middleware/authz.js
@@ -1,29 +1,10 @@
-const { User, Course } = require('../models')
+const { getAuthzForUser } = require('../auth/util')
 
 module.exports = async (req, res, next) => {
-  // Grab the user from the authn stage
+  // Grab the user from the authentication stage
   const { userAuthn } = res.locals
 
-  const staffedCourses = await Course.findAll({
-    where: {
-      '$staff.id$': userAuthn.id,
-    },
-    attributes: ['id'],
-    include: [
-      {
-        model: User,
-        as: 'staff',
-        attributes: [],
-      },
-    ],
-    raw: true,
-  })
-  const staffedCourseIds = staffedCourses.map(row => row.id)
-
-  res.locals.userAuthz = {
-    isAdmin: userAuthn.isAdmin,
-    staffedCourseIds,
-  }
+  res.locals.userAuthz = await getAuthzForUser(userAuthn)
 
   next()
 }

--- a/src/socket/server.js
+++ b/src/socket/server.js
@@ -56,16 +56,18 @@ const handleQuestionCreate = async (id, queueId) => {
 const handleQuestionUpdate = async (id, queueId) => {
   const question = await Question.findOne({ where: { id } })
   // Public confidential queues don't need to know about question updates
-  queueNamespace.to(`queue-${queueId}`).emit('question:update', { question })
   // However, the user that *asked* the question should in fact get this update
   queueNamespace
+    .to(`queue-${queueId}`)
     .to(`queue-${queueId}-user-${question.askedById}`)
     .emit('question:update', { question })
 }
 
 const handleQuestionDelete = (id, queueId) => {
-  queueNamespace.to(`queue-${queueId}`).emit('question:delete', { id })
-  queueNamespace.to(`queue-${queueId}-public`).emit('question:delete', { id })
+  queueNamespace
+    .to(`queue-${queueId}`)
+    .to(`queue-${queueId}-public`)
+    .emit('question:delete', { id })
 }
 
 const handleQuestionEvent = (event, instance) => {
@@ -92,13 +94,17 @@ const handleActiveStaffCreate = id => {
     include: [User],
   }).then(activeStaff => {
     queueNamespace
-      .to(`queue-${activeStaff.queueId}-staff`)
+      .to(`queue-${activeStaff.queueId}`)
+      .to(`queue-${activeStaff.queueId}-public`)
       .emit('activeStaff:create', { id, activeStaff })
   })
 }
 
 const handleActiveStaffDelete = (id, queueId) => {
-  queueNamespace.to(`queue-${queueId}-staff`).emit('activeStaff:delete', { id })
+  queueNamespace
+    .to(`queue-${queueId}`)
+    .to(`queue-${queueId}-public`)
+    .emit('activeStaff:delete', { id })
 }
 
 const handleActiveStaffEvent = (event, instance) => {
@@ -119,7 +125,10 @@ const handleActiveStaffEvent = (event, instance) => {
 
 const handleQueueUpdate = id => {
   Queue.findOne({ where: { id } }).then(queue => {
-    queueNamespace.to(`queue-${id}-staff`).emit('queue:update', { id, queue })
+    queueNamespace
+      .to(`queue-${id}`)
+      .to(`queue-${id}-public`)
+      .emit('queue:update', { id, queue })
   })
 }
 

--- a/test/util.js
+++ b/test/util.js
@@ -74,6 +74,20 @@ module.exports.createTestQuestions = async () => {
       topic: 'Sauce',
       askedById: 2,
     },
+    {
+      queueId: 5,
+      name: 'Student',
+      location: '',
+      topic: 'Secret',
+      askedById: 5,
+    },
+    {
+      queueId: 5,
+      name: 'Other Student',
+      location: '',
+      topic: 'Secret',
+      askedById: 6,
+    },
   ])
 }
 


### PR DESCRIPTION
This is my first attempt at ensuring students can't see the information of other students via the API or websocket updates. I added tests for the API endpoints to ensure they behave correctly. Did my best to share code when possible. I've tested this with some local queues and everything seems to be working correctly. A second set of eyes to make sure I didn't miss any endpoints or weird edge cases would be appreciated!

Thankfully, this doesn't seem to have required any changes to the frontend! Everything "just works" when it receives less information than usual. Thanks to @jackieo5023 for that awesome work 🎉 