### PR TITLE
Await promise in question deletion endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ with the current date and the next changes should go under a **[Next]** header.
 * Validate queue when sending notifications to course staff. ([@james9909](https://github.com/james9909) in [#222](https://github.com/illinois/queue/pull/222))
 * Add a button to delete all questions when the queue is closed. ([@rittikaadhikari](https://github.com/rittikaadhikari) in [#216](https://github.com/illinois/queue/pull/216)
 * Sync logouts between tabs. ([@james9909](https://github.com/james9909) in [#215](https://github.com/illinois/queue/pull/215))
+* Fix promise not being awaited in bulk question deletion endpoint. ([@nwalters512](https://github.com/nwalters512) in [#229](https://github.com/illinois/queue/pull/229)
 
 ## 19 February 2019
 

--- a/src/api/questions.js
+++ b/src/api/questions.js
@@ -143,7 +143,7 @@ router.delete(
   [requireQueue, requireCourseStaffForQueue, failIfErrors],
   safeAsync(async (req, res, _next) => {
     const { id: queueId } = res.locals.queue
-    Question.update(
+    await Question.update(
       {
         dequeueTime: new Date(),
       },


### PR DESCRIPTION
Fixes a bug in #216 where a promise wasn't being awaited in the new question deletion endpoint. This caused errors to print in test cases due to a race condition where the test case cleanup deleted the database before the query actually executed.