### PR TITLE
Improve security for queue settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ When a new version is deployed, the changes since the last deploy should be labe
 with the current date and the next changes should go under a **[Next]** header.
 
 ## [Next]
+* Improve queue settings security. ([@james9909](https://github.com/james9909) in [#233](https://github.com/illinois/queue/pull/233))
 
 ## 13 March 2019
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -991,11 +991,6 @@
       "resolved": "https://registry.npmjs.org/@illinois/react-use-local-storage/-/react-use-local-storage-1.0.1.tgz",
       "integrity": "sha512-LxlgFaICWd6csoWNzbUrhVZGtEFmRk1B+tODwe5sm/eP/HmaNdPM2c7YpRnoFSfQs3SKHa+90B/BSN5eiEdHEg=="
     },
-    "@types/geojson": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-1.0.6.tgz",
-      "integrity": "sha512-Xqg/lIZMrUd0VRmSRbCAewtwGZiAk3mEUDvV4op1tGl+LvyPcb/MIOSxTl9z+9+J+R4/vpjiCAT4xeKzH9ji1w=="
-    },
     "@types/node": {
       "version": "11.9.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-11.9.0.tgz",
@@ -6209,11 +6204,6 @@
       "requires": {
         "is-property": "^1.0.2"
       }
-    },
-    "generic-pool": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.6.1.tgz",
-      "integrity": "sha512-iMmD/pY4q0+V+f8o4twE9JPeqfNuX+gJAaIPB3B0W1lFkBOtTxBo6B0HxHPgGhzQA8jego7EWopcYq/UDJO2KA=="
     },
     "get-caller-file": {
       "version": "1.0.3",
@@ -11945,22 +11935,11 @@
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
     },
     "retry-as-promised": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/retry-as-promised/-/retry-as-promised-2.3.2.tgz",
-      "integrity": "sha1-zZdO5P2bX+A8vzGHHuSCIcB3N7c=",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/retry-as-promised/-/retry-as-promised-3.2.0.tgz",
+      "integrity": "sha512-CybGs60B7oYU/qSQ6kuaFmRd9sTZ6oXSc0toqePvV74Ac6/IFZSI1ReFQmtCN+uvW1Mtqdwpvt/LGOiCBAY2Mg==",
       "requires": {
-        "bluebird": "^3.4.6",
-        "debug": "^2.6.9"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
+        "any-promise": "^1.3.0"
       }
     },
     "rimraf": {
@@ -12165,27 +12144,54 @@
       "integrity": "sha1-1WgS4cAXpuTnw+Ojeh2m143TyT4="
     },
     "sequelize": {
-      "version": "4.42.0",
-      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-4.42.0.tgz",
-      "integrity": "sha512-qxAYnX4rcv7PbNtEidb56REpxNJCdbN0qyk1jb3+e6sE7OrmS0nYMU+MFVbNTJtZfSpOEEL1TX0TkMw+wzZBxg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-5.1.0.tgz",
+      "integrity": "sha512-LmjEAedMTItkIx0mcBfXVmdkkIQOc+1reuv+UpqSADGvQofZ4Sn9ElUBE8egLgCK4oWjy1Ybsju+YDAJpCv1ww==",
       "requires": {
         "bluebird": "^3.5.0",
         "cls-bluebird": "^2.1.0",
-        "debug": "^3.1.0",
-        "depd": "^1.1.0",
+        "debug": "^4.1.1",
+        "depd": "^2.0.0",
         "dottie": "^2.0.0",
-        "generic-pool": "^3.4.0",
         "inflection": "1.12.0",
-        "lodash": "^4.17.1",
-        "moment": "^2.20.0",
-        "moment-timezone": "^0.5.14",
-        "retry-as-promised": "^2.3.2",
-        "semver": "^5.5.0",
-        "terraformer-wkt-parser": "^1.1.2",
+        "lodash": "^4.17.11",
+        "moment": "^2.24.0",
+        "moment-timezone": "^0.5.21",
+        "retry-as-promised": "^3.1.0",
+        "semver": "^5.6.0",
+        "sequelize-pool": "^1.0.2",
         "toposort-class": "^1.0.1",
         "uuid": "^3.2.1",
-        "validator": "^10.4.0",
-        "wkx": "^0.4.1"
+        "validator": "^10.11.0",
+        "wkx": "^0.4.6"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "depd": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+          "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        }
+      }
+    },
+    "sequelize-pool": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/sequelize-pool/-/sequelize-pool-1.0.2.tgz",
+      "integrity": "sha512-VMKl/gCCdIvB1gFZ7p+oqLFEyZEz3oMMYjkKvfEC7GoO9bBcxmfOOU9RdkoltfXGgBZFigSChihRly2gKtsh2w==",
+      "requires": {
+        "bluebird": "^3.5.3"
       }
     },
     "sequelize-stream": {
@@ -13045,23 +13051,6 @@
           "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
           "dev": true
         }
-      }
-    },
-    "terraformer": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/terraformer/-/terraformer-1.0.9.tgz",
-      "integrity": "sha512-YlmQ1fsMWTkKGDGibCRWgmLzrpDRUr63Q025LJ/taYQ6j1Yb8q9McKF7NBi6ACAyUXO6F/bl9w6v4MY307y5Ag==",
-      "requires": {
-        "@types/geojson": "^1.0.0"
-      }
-    },
-    "terraformer-wkt-parser": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/terraformer-wkt-parser/-/terraformer-wkt-parser-1.2.0.tgz",
-      "integrity": "sha512-QU3iA54St5lF8Za1jg1oj4NYc8sn5tCZ08aNSWDeGzrsaV48eZk1iAVWasxhNspYBoCqdHuoot1pUTUrE1AJ4w==",
-      "requires": {
-        "@types/geojson": "^1.0.0",
-        "terraformer": "~1.0.5"
       }
     },
     "terser": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "redux": "^4.0.1",
     "redux-thunk": "^2.3.0",
     "reselect": "^4.0.0",
-    "sequelize": "^4.42.0",
+    "sequelize": "^5.1.0",
     "sequelize-stream": "^1.0.2",
     "socket.io": "^2.2.0",
     "socket.io-client": "^2.2.0",

--- a/src/api/questions.js
+++ b/src/api/questions.js
@@ -137,17 +137,21 @@ router.post(
       }
     }
 
-    const question = Question.build({
-      name: data.name,
-      // Questions in fixed-location queues should never have a location
-      location: res.locals.queue.fixedLocation ? '' : data.location,
-      topic: data.topic,
-      enqueueTime: new Date(),
-      queueId,
-      askedById: askerId,
-    })
+    const question = await Question.create(
+      {
+        name: data.name,
+        // Questions in fixed-location queues should never have a location
+        location: res.locals.queue.fixedLocation ? '' : data.location,
+        topic: data.topic,
+        enqueueTime: new Date(),
+        queueId,
+        askedById: askerId,
+      },
+      {
+        include: [{ model: User, as: 'askedBy' }],
+      }
+    )
 
-    await question.save()
     await question.reload()
     res.status(201).send(question)
   })

--- a/src/api/questions.js
+++ b/src/api/questions.js
@@ -13,7 +13,7 @@ const {
   requireQueueForQuestion,
   requireQuestion,
   failIfErrors,
-  canUserSeeQuestionDetailsForConfidentialQueue,
+  isUserStudent,
   filterConfidentialQueueQuestionsForUser,
   ApiError,
 } = require('./util')
@@ -173,7 +173,7 @@ router.get(
     )
     if (isConfidential) {
       const { userAuthz } = res.locals
-      if (!canUserSeeQuestionDetailsForConfidentialQueue(userAuthz, courseId)) {
+      if (isUserStudent(userAuthz, courseId)) {
         const { id: userId } = res.locals.userAuthn
         questions = filterConfidentialQueueQuestionsForUser(userId, questions)
       }
@@ -191,7 +191,7 @@ router.get(
     if (isConfidential) {
       const { id: userId } = res.locals.userAuthn
       const { userAuthz } = res.locals
-      if (!canUserSeeQuestionDetailsForConfidentialQueue(userAuthz, courseId)) {
+      if (isUserStudent(userAuthz, courseId)) {
         if (res.locals.question.askedById !== userId) {
           res.status(403).send('You are not authorized to access that question')
           return

--- a/src/api/queues.js
+++ b/src/api/queues.js
@@ -86,21 +86,12 @@ router.get(
   '/:queueId',
   [requireQueue, failIfErrors],
   safeAsync(async (req, res, _next) => {
-    const { id: queueId } = res.locals.queue
-    let queueResult = await Queue.findOne({
-      where: {
-        id: queueId,
-      },
-      attributes: ['courseId'],
-    })
-
-    // Convert to plain object that we can manipulate/filter/etc. before
-    // sending back to the client
+    const { id: queueId, courseId } = res.locals.queue
     const { userAuthz } = res.locals
-    const isStudent = isUserStudent(userAuthz, queueResult.courseId)
+    const isStudent = isUserStudent(userAuthz, courseId)
 
     const scope = isStudent ? 'defaultScope' : 'courseStaff'
-    queueResult = await Queue.scope(scope).findOne({
+    const queueResult = await Queue.scope(scope).findOne({
       where: {
         id: queueId,
       },

--- a/src/api/queues.js
+++ b/src/api/queues.js
@@ -113,6 +113,7 @@ router.get(
           },
           required: false,
           include: [User],
+          attributes: ['startTime', 'endTime'],
         },
         {
           model: Question,
@@ -120,6 +121,17 @@ router.get(
           where: {
             dequeueTime: null,
           },
+          attributes: [
+            'id',
+            'name',
+            'topic',
+            'beingAnswered',
+            'answerStartTime',
+            'enqueueTime',
+            'dequeueTime',
+            'askedById',
+          ],
+          include: [{ model: User, as: 'askedBy' }],
         },
       ],
       order: [[Question, 'id', 'ASC']],

--- a/src/api/queues.test.js
+++ b/src/api/queues.test.js
@@ -40,11 +40,8 @@ describe('Queues API', () => {
       expect(res.body[1].id).toBe(2)
 
       res.body.forEach(queue => {
-        if (user === 'admin') {
-          includesPrivateAttributes(queue)
-        } else {
-          excludesPrivateAttributes(queue)
-        }
+        // This endpoint shouldn't include private attributes
+        excludesPrivateAttributes(queue)
       })
     }
     test('succeeds for admin', async () => {

--- a/src/api/util.js
+++ b/src/api/util.js
@@ -65,10 +65,10 @@ const requireModelForModel = (
   next()
 }
 
-const canUserSeeQuestionDetailsForConfidentialQueue = (userAuthz, courseId) => {
+const isUserStudent = (userAuthz, courseId) => {
   const { isAdmin, staffedCourseIds } = userAuthz
   const staffsQueue = staffedCourseIds.findIndex(id => id === courseId) !== -1
-  return isAdmin || staffsQueue
+  return !isAdmin && !staffsQueue
 }
 
 /**
@@ -114,6 +114,6 @@ module.exports = {
   requireModel,
 
   // Stuff for confidential queues
-  canUserSeeQuestionDetailsForConfidentialQueue,
+  isUserStudent,
   filterConfidentialQueueQuestionsForUser,
 }

--- a/src/api/util.test.js
+++ b/src/api/util.test.js
@@ -106,41 +106,32 @@ describe('Testing Utils', () => {
     })
   })
 
-  describe('canUserSeeQuestionDetailsForConfidentialQueue', () => {
-    test('returns true for an admin', () => {
+  describe('isUserStudent', () => {
+    test('returns false for an admin', () => {
       const userAuthz = {
         isAdmin: true,
         staffedCourseIds: [],
       }
-      const value = util.canUserSeeQuestionDetailsForConfidentialQueue(
-        userAuthz,
-        123
-      )
-      expect(value).toBeTruthy()
+      const value = util.isUserStudent(userAuthz, 123)
+      expect(value).toBeFalsy()
     })
 
-    test('returns true for course staff', () => {
+    test('returns false for course staff', () => {
       const userAuthz = {
         isAdmin: false,
         staffedCourseIds: [123],
       }
-      const value = util.canUserSeeQuestionDetailsForConfidentialQueue(
-        userAuthz,
-        123
-      )
-      expect(value).toBeTruthy()
+      const value = util.isUserStudent(userAuthz, 123)
+      expect(value).toBeFalsy()
     })
 
-    test('returns false for non-admin, non-course staff', () => {
+    test('returns true for non-admin, non-course staff', () => {
       const userAuthz = {
         isAdmin: false,
         staffedCourseIds: [],
       }
-      const value = util.canUserSeeQuestionDetailsForConfidentialQueue(
-        userAuthz,
-        123
-      )
-      expect(value).toBeFalsy()
+      const value = util.isUserStudent(userAuthz, 123)
+      expect(value).toBeTruthy()
     })
   })
 

--- a/src/models/Queue.js
+++ b/src/models/Queue.js
@@ -1,4 +1,6 @@
 module.exports = (sequelize, DataTypes) => {
+  const privateAttributes = ['admissionControlEnabled', 'admissionControlUrl']
+
   const obj = sequelize.define(
     'queue',
     {
@@ -66,6 +68,8 @@ module.exports = (sequelize, DataTypes) => {
       ],
     })
   }
+
+  obj.privateAttributes = privateAttributes
 
   return obj
 }

--- a/src/models/Queue.js
+++ b/src/models/Queue.js
@@ -1,6 +1,4 @@
 module.exports = (sequelize, DataTypes) => {
-  const privateAttributes = ['admissionControlEnabled', 'admissionControlUrl']
-
   const obj = sequelize.define(
     'queue',
     {
@@ -36,6 +34,14 @@ module.exports = (sequelize, DataTypes) => {
       defaultScope: {
         attributes: {
           include: ['courseId', 'createdByUserId'],
+          exclude: ['admissionControlEnabled', 'admissionControlUrl'],
+        },
+      },
+      scopes: {
+        courseStaff: {
+          attributes: {
+            include: ['courseId', 'createdByUserId'],
+          },
         },
       },
     }
@@ -68,8 +74,6 @@ module.exports = (sequelize, DataTypes) => {
       ],
     })
   }
-
-  obj.privateAttributes = privateAttributes
 
   return obj
 }

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -38,7 +38,8 @@ module.exports.initSequelize = sequelize => {
 }
 
 const sequelizeConfig = {
-  operatorsAliases: Sequelize.Op,
+  // See http://docs.sequelizejs.com/manual/querying.html#operators-security
+  operatorsAliases: false,
   dialectOptions: {
     multipleStatements: true,
   },

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -38,8 +38,6 @@ module.exports.initSequelize = sequelize => {
 }
 
 const sequelizeConfig = {
-  // See http://docs.sequelizejs.com/manual/querying.html#operators-security
-  operatorsAliases: false,
   dialectOptions: {
     multipleStatements: true,
   },

--- a/src/pages/queueSettings.js
+++ b/src/pages/queueSettings.js
@@ -101,7 +101,8 @@ const mapDispatchToProps = dispatch => ({
   dispatch,
 })
 
+const permissions = { requireCourseStaff: true }
 export default connect(
   mapStateToProps,
   mapDispatchToProps
-)(PageWithUser(QueueSettings))
+)(PageWithUser(QueueSettings, permissions))

--- a/src/socket/server.js
+++ b/src/socket/server.js
@@ -5,7 +5,7 @@ const logger = require('../util/logger')
 const { sequelize, Question, User, ActiveStaff, Queue } = require('../models')
 const { getUserFromJwt, getAuthzForUser } = require('../auth/util')
 const {
-  canUserSeeQuestionDetailsForConfidentialQueue,
+  isUserStudent,
   filterConfidentialQueueQuestionsForUser,
 } = require('../api/util')
 
@@ -201,12 +201,9 @@ module.exports = newIo => {
           userAuthzPromise,
         ])
         const { courseId, isConfidential } = queue
-        const canSeeQuestionDetails = canUserSeeQuestionDetailsForConfidentialQueue(
-          userAuthz,
-          courseId
-        )
+        const isStudent = !isUserStudent(userAuthz, courseId)
         let sendCompleteQuestionData = true
-        if (isConfidential && !canSeeQuestionDetails) {
+        if (isConfidential && isStudent) {
           // All users that shouldn't see confidential information are added
           // to a "public" version of the room that receives the minimum
           // possible set of information


### PR DESCRIPTION
The queue settings page can now only be viewed by course staff or queue admins, and will 403 otherwise. 

I also noticed `admissionControlUrl` is not being filtered out on queue GET requests - is this something we want to hide from regular users?