### PR TITLE
Confidential queue fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ with the current date and the next changes should go under a **[Next]** header.
 
 ## [Next]
 
+* Fix confidential queue not being shown correctly to course staff by using `isUserCourseStaffForQueue` instead of `isUserCourseStaff`. ([@jackieo5023](https://github.com/jackieo5023) in [#234](https://github.com/illinois/queue/pull/234))
+
 ## 13 March 2019
 
 * Add user-facing error messages. ([@james9909](https://github.com/james9909) in [#195](https://github.com/illinois/queue/pull/195))
@@ -17,7 +19,6 @@ with the current date and the next changes should go under a **[Next]** header.
 * Add debugging prints to help identify cause of ActiveStaff query error. ([@nwalters512](https://github.com/nwalters512) in [#231](https://github.com/illinois/queue/pull/231))
 * Implement confidential queues. ([@jackieo5023](https://github.com/jackieo5023) and [@nwalters512](https://github.com/nwalters512) in [#230](https://github.com/illinois/queue/pull/230))
 * Implement programmatic admission control. ([@nwalters512](https://github.com/nwalters512) in [#228](https://github.com/illinois/queue/pull/228))
-* Fix confidential queue not being shown correctly to course staff by using `isUserCourseStaffForQueue` instead of `isUserCourseStaff`. ([@jackieo5023](https://github.com/jackieo5023) in [#234](https://github.com/illinois/queue/pull/234))
 
 ## 19 February 2019
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,6 @@ with the current date and the next changes should go under a **[Next]** header.
 * Fix promise not being awaited in bulk question deletion endpoint. ([@nwalters512](https://github.com/nwalters512) in [#229](https://github.com/illinois/queue/pull/229))
 * Add debugging prints to help identify cause of ActiveStaff query error. ([@nwalters512](https://github.com/nwalters512) in [#231](https://github.com/illinois/queue/pull/231))
 * Implement confidential queues. ([@jackieo5023 ](https://github.com/jackieo5023 ) and [@nwalters512](https://github.com/nwalters512) in [#230](https://github.com/illinois/queue/pull/230))
-* Implement programmatic admission control. ([@nwalters512](https://github.com/nwalters512) in [#228](https://github.com/illinois/queue/pull/228))
 
 ## 19 February 2019
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ with the current date and the next changes should go under a **[Next]** header.
 * Add debugging prints to help identify cause of ActiveStaff query error. ([@nwalters512](https://github.com/nwalters512) in [#231](https://github.com/illinois/queue/pull/231))
 * Implement confidential queues. ([@jackieo5023 ](https://github.com/jackieo5023 ) and [@nwalters512](https://github.com/nwalters512) in [#230](https://github.com/illinois/queue/pull/230))
 * Implement programmatic admission control. ([@nwalters512](https://github.com/nwalters512) in [#228](https://github.com/illinois/queue/pull/228))
+* Fix confidential queue not being shown correctly to course staff by using isUserCourseStaffForQueue instead of isUserCourseStaff. ([@jackieo5023 ](https://github.com/jackieo5023) in [#234](https://github.com/illinois/queue/pull/234))
 
 ## 19 February 2019
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ with the current date and the next changes should go under a **[Next]** header.
 * Fix promise not being awaited in bulk question deletion endpoint. ([@nwalters512](https://github.com/nwalters512) in [#229](https://github.com/illinois/queue/pull/229))
 * Add debugging prints to help identify cause of ActiveStaff query error. ([@nwalters512](https://github.com/nwalters512) in [#231](https://github.com/illinois/queue/pull/231))
 * Implement confidential queues. ([@jackieo5023 ](https://github.com/jackieo5023 ) and [@nwalters512](https://github.com/nwalters512) in [#230](https://github.com/illinois/queue/pull/230))
+* Implement programmatic admission control. ([@nwalters512](https://github.com/nwalters512) in [#228](https://github.com/illinois/queue/pull/228))
 
 ## 19 February 2019
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,9 @@ with the current date and the next changes should go under a **[Next]** header.
 * Sync logouts between tabs. ([@james9909](https://github.com/james9909) in [#215](https://github.com/illinois/queue/pull/215))
 * Fix promise not being awaited in bulk question deletion endpoint. ([@nwalters512](https://github.com/nwalters512) in [#229](https://github.com/illinois/queue/pull/229))
 * Add debugging prints to help identify cause of ActiveStaff query error. ([@nwalters512](https://github.com/nwalters512) in [#231](https://github.com/illinois/queue/pull/231))
-* Implement confidential queues. ([@jackieo5023 ](https://github.com/jackieo5023 ) and [@nwalters512](https://github.com/nwalters512) in [#230](https://github.com/illinois/queue/pull/230))
+* Implement confidential queues. ([@jackieo5023](https://github.com/jackieo5023) and [@nwalters512](https://github.com/nwalters512) in [#230](https://github.com/illinois/queue/pull/230))
 * Implement programmatic admission control. ([@nwalters512](https://github.com/nwalters512) in [#228](https://github.com/illinois/queue/pull/228))
-* Fix confidential queue not being shown correctly to course staff by using isUserCourseStaffForQueue instead of isUserCourseStaff. ([@jackieo5023 ](https://github.com/jackieo5023) in [#234](https://github.com/illinois/queue/pull/234))
+* Fix confidential queue not being shown correctly to course staff by using `isUserCourseStaffForQueue` instead of `isUserCourseStaff`. ([@jackieo5023](https://github.com/jackieo5023) in [#234](https://github.com/illinois/queue/pull/234))
 
 ## 19 February 2019
 

--- a/src/pages/queue.js
+++ b/src/pages/queue.js
@@ -27,7 +27,7 @@ import QuestionNotificationsToggle from '../components/QuestionNotificationsTogg
 import QueueStatusToggleContainer from '../containers/QueueStatusToggleContainer'
 import DeleteAllQuestionsButtonContainer from '../containers/DeleteAllQuestionsButtonContainer'
 import QueueMessageEnabledToggleContainer from '../containers/QueueMessageEnabledToggleContainer'
-import { isUserCourseStaff, isUserAdmin } from '../selectors'
+import { isUserCourseStaffForQueue, isUserAdmin } from '../selectors'
 import ConfidentialQueuePanelContainer from '../containers/ConfidentialQueuePanelContainer'
 
 class Queue extends React.Component {
@@ -175,7 +175,7 @@ const mapStateToProps = (state, ownProps) => ({
   isFetching: state.queues.isFetching,
   hasQueue: !!state.queues.queues[ownProps.queueId],
   queue: state.queues.queues[ownProps.queueId],
-  isUserCourseStaff: isUserCourseStaff(state, ownProps),
+  isUserCourseStaff: isUserCourseStaffForQueue(state, ownProps),
   isUserAdmin: isUserAdmin(state, ownProps),
 })
 


### PR DESCRIPTION
`isUserCourseStaff` was being used as a selector on the `queue.js` page, but there was no concept of a `course` prop to get the id.   This is now changed to `isUserCourseStaffForQueue`, which uses the `queue.courseId` prop.