### PR TITLE
Show course name on queue page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ with the current date and the next changes should go under a **[Next]** header.
 
 ## [Next]
 * Improve queue settings security. ([@james9909](https://github.com/james9909) in [#233](https://github.com/illinois/queue/pull/233))
-
 * Fix confidential queue not being shown correctly to course staff by using `isUserCourseStaffForQueue` instead of `isUserCourseStaff`. ([@jackieo5023](https://github.com/jackieo5023) in [#234](https://github.com/illinois/queue/pull/234))
+* Show course name on queue page. ([@nwalters512](https://github.com/nwalters512) in [#236](https://github.com/illinois/queue/pull/236))
 
 ## 13 March 2019
 

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -54,10 +54,10 @@ class Header extends React.Component {
     // login page
     const brandLink = user ? (
       <Link route="index" passHref>
-        <NavbarBrand>Queues@Illinois</NavbarBrand>
+        <NavbarBrand>Queue@Illinois</NavbarBrand>
       </Link>
     ) : (
-      <NavbarBrand tag="span">Queues@Illinois</NavbarBrand>
+      <NavbarBrand tag="span">Queue@Illinois</NavbarBrand>
     )
 
     return (

--- a/src/pages/_document.js
+++ b/src/pages/_document.js
@@ -46,7 +46,7 @@ export default class MyDocument extends Document {
             crossOrigin="use-credentials"
             href={manifestPath}
           />
-          <title>Queues@Illinois</title>
+          <title>Queue@Illinois</title>
           <style>{dom.css()}</style>
           <link rel="icon" href={faviconPath} type="image/png" />
           <script dangerouslySetInnerHTML={script} />

--- a/src/pages/queue.js
+++ b/src/pages/queue.js
@@ -51,7 +51,7 @@ class Queue extends React.Component {
         this.props.pageTransitionReadyToEnter()
       }
       // We won't block the page from showing while we load the course - we'll
-      // simply slow the course name as soon as it's available
+      // simply show the course name as soon as it's available
       return this.props.fetchCourse(action.queue.courseId)
     })
   }

--- a/src/static/manifest.json
+++ b/src/static/manifest.json
@@ -1,5 +1,5 @@
 {
-  "name": "Queues@Illinois",
+  "name": "Queue@Illinois",
   "short_name": "Queues",
   "display": "standalone",
   "background_color": "#fff",


### PR DESCRIPTION
Like #232, but without modifying the existing API. We just load the course and display the name as soon as we can.

Closes #232, Closes #138, Closes #31