### PR TITLE
Fix user names not being shown on course staff list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,13 @@ Each PR must be accompanied by one or more corresponding changelog entries.
 When a new version is tagged, the changes since the last deploy should be labeled
 with the current semantic version and the next changes should go under a **[Next]** header.
 
+## [Next]
+
+* Fix user names not being shown on the course staff page. ([@nwalters512](https://github.com/nwalters512) in [#240](https://github.com/illinois/queue/pull/240))
+
 ## v1.0.0
 *Note: prior to this release, versions were tagged based on the date they were deployed.*
+
 * Improve queue settings security. ([@james9909](https://github.com/james9909) in [#233](https://github.com/illinois/queue/pull/233))
 * Fix confidential queue not being shown correctly to course staff by using `isUserCourseStaffForQueue` instead of `isUserCourseStaff`. ([@jackieo5023](https://github.com/jackieo5023) in [#234](https://github.com/illinois/queue/pull/234))
 * Show course name on queue page. ([@nwalters512](https://github.com/nwalters512) in [#236](https://github.com/illinois/queue/pull/236))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 Each PR must be accompanied by one or more corresponding changelog entries.
-When a new version is deployed, the changes since the last deploy should be labeled
-with the current date and the next changes should go under a **[Next]** header.
+When a new version is tagged, the changes since the last deploy should be labeled
+with the current semantic version and the next changes should go under a **[Next]** header.
 
-## [Next]
+## v1.0.0
+*Note: prior to this release, versions were tagged based on the date they were deployed.*
 * Improve queue settings security. ([@james9909](https://github.com/james9909) in [#233](https://github.com/illinois/queue/pull/233))
 * Fix confidential queue not being shown correctly to course staff by using `isUserCourseStaffForQueue` instead of `isUserCourseStaff`. ([@jackieo5023](https://github.com/jackieo5023) in [#234](https://github.com/illinois/queue/pull/234))
 * Show course name on queue page. ([@nwalters512](https://github.com/nwalters512) in [#236](https://github.com/illinois/queue/pull/236))

--- a/src/api/courses.js
+++ b/src/api/courses.js
@@ -47,6 +47,11 @@ router.get(
       where: { id: courseId },
       include: includes,
     })).toJSON()
+    // This is a workaround to https://github.com/sequelize/sequelize/issues/10552
+    // TODO remove this once the issue is fixed in sequelize
+    course.staff = course.staff.map(user => {
+      return { name: user.preferredName || user.universityName, ...user }
+    })
 
     // It turns out that sequelize can only generate queries that include the
     // question count if we query for queues separately from the course

--- a/src/api/courses.js
+++ b/src/api/courses.js
@@ -28,11 +28,10 @@ router.get(
     } = res
 
     const includes = []
+    const includeStaffList =
+      userAuthz.isAdmin || userAuthz.staffedCourseIds.indexOf(courseId) !== -1
     // Only include list of course staff for other course staff or admins
-    if (
-      userAuthz.isAdmin ||
-      userAuthz.staffedCourseIds.indexOf(courseId) !== -1
-    ) {
+    if (includeStaffList) {
       includes.push({
         model: User,
         as: 'staff',
@@ -47,11 +46,14 @@ router.get(
       where: { id: courseId },
       include: includes,
     })).toJSON()
-    // This is a workaround to https://github.com/sequelize/sequelize/issues/10552
-    // TODO remove this once the issue is fixed in sequelize
-    course.staff = course.staff.map(user => {
-      return { name: user.preferredName || user.universityName, ...user }
-    })
+
+    if (includeStaffList) {
+      // This is a workaround to https://github.com/sequelize/sequelize/issues/10552
+      // TODO remove this once the issue is fixed in sequelize
+      course.staff = course.staff.map(user => {
+        return { name: user.preferredName || user.universityName, ...user }
+      })
+    }
 
     // It turns out that sequelize can only generate queries that include the
     // question count if we query for queues separately from the course

--- a/src/api/courses.test.js
+++ b/src/api/courses.test.js
@@ -51,6 +51,7 @@ describe('Courses API', () => {
       expect(res.body).toHaveProperty('staff')
       expect(res.body.staff).toHaveLength(1)
       expect(res.body.staff[0].netid).toBe('241staff')
+      expect(res.body.staff[0].name).toBe('241 Staff')
       expect(res.body.staff[0].id).toBe(4)
     })
 

--- a/test/util.js
+++ b/test/util.js
@@ -14,9 +14,9 @@ module.exports.destroyTestDb = async () => {
 module.exports.createTestUsers = async () => {
   await models.User.bulkCreate([
     { netid: 'dev', isAdmin: true },
-    { netid: 'admin', isAdmin: true },
-    { netid: '225staff', isAdmin: false },
-    { netid: '241staff', isAdmin: false },
+    { netid: 'admin', universityName: 'Admin', isAdmin: true },
+    { netid: '225staff', universityName: '225 Staff', isAdmin: false },
+    { netid: '241staff', universityName: '241 Staff', isAdmin: false },
     { netid: 'student', isAdmin: false },
     { netid: 'otherstudent', isAdmin: false },
   ])


### PR DESCRIPTION
This is a temporary fix, pending https://github.com/sequelize/sequelize/issues/10552 being fixed. Closes #238.