### PR TITLE
Add user-facing warning about socket errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ with the current semantic version and the next changes should go under a **[Next
 
 ## [Next]
 
+* Add user-facing warning about socket errors to help track down [#241](https://github.com/illinois/queue/issues/241). ([@nwalters512](https://github.com/nwalters512) in [#250](https://github.com/illinois/queue/pull/250))  
+
 ## v1.0.2
 
 * Add debugging logs to help track down [#241](https://github.com/illinois/queue/issues/241). ([@nwalters512](https://github.com/nwalters512) in [#242](https://github.com/illinois/queue/pull/242)) 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9746,9 +9746,9 @@
       }
     },
     "next-page-transitions": {
-      "version": "1.0.0-alpha.6",
-      "resolved": "https://registry.npmjs.org/next-page-transitions/-/next-page-transitions-1.0.0-alpha.6.tgz",
-      "integrity": "sha512-Sfc+MMCXHLDmAL57MkPuyWck4q5OyS1mV0c8SMQ15howljDl2Rh/h/SSWo/hSXcBgsnnZ/UHd677MVsggFZqEw==",
+      "version": "1.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/next-page-transitions/-/next-page-transitions-1.0.0-beta.1.tgz",
+      "integrity": "sha512-xjYkUyZfsV1qyfGHV2mmJS6icFY1VbvrC2wh9nucXd1U2zOTHWR+9CsWTSckghk4IJbnk6Ll/6RyRpexTiGodA==",
       "requires": {
         "prop-types": "^15.6.1",
         "react-transition-group": "^2.3.1"

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "moment": "^2.24.0",
     "mysql2": "^1.6.5",
     "next": "^8.0.0",
-    "next-page-transitions": "^1.0.0-alpha.6",
+    "next-page-transitions": "^1.0.0-beta.1",
     "next-redux-wrapper": "^3.0.0-alpha.1",
     "next-routes": "^1.4.2",
     "normalizr": "^3.3.0",

--- a/src/actions/socket.js
+++ b/src/actions/socket.js
@@ -1,0 +1,11 @@
+import { makeActionCreator } from './util'
+import * as types from '../constants/ActionTypes'
+
+export const setSocketError = makeActionCreator(types.SET_SOCKET_ERROR, 'error')
+
+export const setSocketStatus = makeActionCreator(
+  types.SET_SOCKET_STATUS,
+  'status'
+)
+
+export const resetSocketState = makeActionCreator(types.RESET_SOCKET_STATE)

--- a/src/components/SocketErrorModal.jsx
+++ b/src/components/SocketErrorModal.jsx
@@ -1,0 +1,41 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Modal, ModalHeader, ModalBody } from 'reactstrap'
+
+const SocketErrorModal = ({ isOpen, toggle, error }) => (
+  <Modal isOpen={isOpen} toggle={toggle}>
+    <ModalHeader>Socket error</ModalHeader>
+    <ModalBody>
+      <p>
+        There was an error connecting to the socket to receive realtime updates.
+        This is a known issue and we are working to identify the root cause. If
+        you&apos;d like to help us fix this problem, please reach out to Wade at{' '}
+        <a href="mailto:waf@illinois.edu">waf@illinois.edu</a> so that the Queue
+        developers can get in touch with you! In the meantime, please try
+        accessing the Queue from another browser or device.
+      </p>
+      {error && (
+        <>
+          <p>
+            <b>Please include the below message in your email:</b>
+          </p>
+          <pre>
+            <code>{error}</code>
+          </pre>
+        </>
+      )}
+    </ModalBody>
+  </Modal>
+)
+
+SocketErrorModal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  toggle: PropTypes.func.isRequired,
+  error: PropTypes.string,
+}
+
+SocketErrorModal.defaultProps = {
+  error: null,
+}
+
+export default SocketErrorModal

--- a/src/constants/ActionTypes.js
+++ b/src/constants/ActionTypes.js
@@ -42,3 +42,8 @@ export const UPDATE_USER_PREFERRED_NAME = makeActionStrings(
 export const REPLACE_QUESTIONS = 'REPLACE_QUESTIONS'
 export const UPDATE_QUEUES = 'UPDATE_QUEUES'
 export const REPLACE_ACTIVE_STAFF = 'REPLACE_ACTIVE_STAFF'
+
+/* Actions for socket status */
+export const SET_SOCKET_STATUS = 'SET_SOCKET_STATUS'
+export const SET_SOCKET_ERROR = 'SET_SOCKET_ERROR'
+export const RESET_SOCKET_STATE = 'RESET_SOCKET_STATE'

--- a/src/pages/queue.js
+++ b/src/pages/queue.js
@@ -32,6 +32,7 @@ import QueueMessageEnabledToggleContainer from '../containers/QueueMessageEnable
 import { isUserCourseStaffForQueue, isUserAdmin } from '../selectors'
 import ConfidentialQueuePanelContainer from '../containers/ConfidentialQueuePanelContainer'
 import SocketErrorModal from '../components/SocketErrorModal'
+import { resetSocketState } from '../actions/socket'
 
 class Queue extends React.Component {
   static getInitialProps({ isServer, store, query }) {
@@ -72,6 +73,7 @@ class Queue extends React.Component {
 
   componentWillUnmount() {
     disconnectFromQueue(this.props.queueId)
+    resetSocketState()
   }
 
   render() {
@@ -217,6 +219,7 @@ const mapStateToProps = (state, ownProps) => {
 const mapDispatchToProps = dispatch => ({
   fetchQueue: queueId => dispatch(fetchQueue(queueId)),
   fetchCourse: courseId => dispatch(fetchCourse(courseId)),
+  resetSocketState: () => dispatch(resetSocketState()),
   dispatch,
 })
 

--- a/src/pages/queue.js
+++ b/src/pages/queue.js
@@ -9,7 +9,6 @@ import {
   CardBody,
   Collapse,
   UncontrolledTooltip,
-  Alert,
 } from 'reactstrap'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faMapMarker, faEyeSlash } from '@fortawesome/free-solid-svg-icons'

--- a/src/pages/queue.js
+++ b/src/pages/queue.js
@@ -9,6 +9,7 @@ import {
   CardBody,
   Collapse,
   UncontrolledTooltip,
+  Alert,
 } from 'reactstrap'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faMapMarker, faEyeSlash } from '@fortawesome/free-solid-svg-icons'
@@ -30,6 +31,7 @@ import DeleteAllQuestionsButtonContainer from '../containers/DeleteAllQuestionsB
 import QueueMessageEnabledToggleContainer from '../containers/QueueMessageEnabledToggleContainer'
 import { isUserCourseStaffForQueue, isUserAdmin } from '../selectors'
 import ConfidentialQueuePanelContainer from '../containers/ConfidentialQueuePanelContainer'
+import SocketErrorModal from '../components/SocketErrorModal'
 
 class Queue extends React.Component {
   static getInitialProps({ isServer, store, query }) {
@@ -155,6 +157,10 @@ class Queue extends React.Component {
             <QuestionListContainer queueId={this.props.queueId} />
           </Col>
         </Row>
+        <SocketErrorModal
+          isOpen={!!this.props.socketError}
+          error={this.props.socketError}
+        />
       </Container>
     )
   }
@@ -183,12 +189,14 @@ Queue.propTypes = {
     name: PropTypes.string,
   }),
   pageTransitionReadyToEnter: PropTypes.func,
+  socketError: PropTypes.string,
 }
 
 Queue.defaultProps = {
   queue: null,
   course: null,
   pageTransitionReadyToEnter: null,
+  socketError: null,
 }
 
 const mapStateToProps = (state, ownProps) => {
@@ -202,6 +210,7 @@ const mapStateToProps = (state, ownProps) => {
     course,
     isUserCourseStaff: isUserCourseStaffForQueue(state, ownProps),
     isUserAdmin: isUserAdmin(state, ownProps),
+    socketError: state.socket.error,
   }
 }
 

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -5,6 +5,7 @@ import questions from './questions'
 import queues from './queues'
 import users from './users'
 import user from './user'
+import socket from './socket'
 
 const Reducer = combineReducers({
   activeStaff,
@@ -13,6 +14,7 @@ const Reducer = combineReducers({
   queues,
   users,
   user,
+  socket,
 })
 
 export default Reducer

--- a/src/reducers/socket.js
+++ b/src/reducers/socket.js
@@ -1,0 +1,33 @@
+import {
+  SET_SOCKET_STATUS,
+  SET_SOCKET_ERROR,
+  RESET_SOCKET_STATE,
+} from '../constants/ActionTypes'
+
+const defaultState = {
+  status: null,
+  error: null,
+}
+
+const socket = (state = defaultState, action) => {
+  switch (action.type) {
+    case SET_SOCKET_STATUS:
+      return {
+        ...state,
+        status: action.status,
+      }
+    case SET_SOCKET_ERROR:
+      return {
+        ...state,
+        error: action.error,
+      }
+    case RESET_SOCKET_STATE:
+      return {
+        ...defaultState,
+      }
+    default:
+      return state
+  }
+}
+
+export default socket

--- a/src/socket/client.js
+++ b/src/socket/client.js
@@ -13,6 +13,7 @@ import {
 import { replaceActiveStaff } from '../actions/activeStaff'
 import { normalizeActiveStaff } from '../reducers/normalize'
 import { baseUrl } from '../util'
+import { setSocketError } from '../actions/socket'
 
 const socketOpts = {
   path: `${baseUrl}/socket.io`,
@@ -54,6 +55,14 @@ export const connectToQueue = (dispatch, queueId) => {
       dispatch(replaceQuestions(queueId, questions))
       dispatch(replaceActiveStaff(queueId, activeStaff))
     })
+  })
+  socket.on('connect_failed', err => {
+    dispatch(setSocketError(err))
+    console.error(err)
+  })
+  socket.on('error', err => {
+    dispatch(setSocketError(err))
+    console.error(err)
   })
   socket.on('question:create', ({ question }) =>
     handleQuestionCreate(dispatch, queueId, question)


### PR DESCRIPTION
This shows a modal to the user if the socket fails to connect. To test, you can add the following code to `src/socket/server.js` in the `io.use(...)` authentication middleware:

```js
next(new Error('rip'))
return
```

The `setSocketStatus` action isn't in use yet, but I figured we could use that in the future to show an indicator of if the socket is connected to, is reconnecting, errored, etc.