### PR TITLE
Improve header accessibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ with the current semantic version and the next changes should go under a **[Next
 
 ## [Next]
 
+* Improve accessibility of the page header. ([@nwalters512](https://github.com/nwalters512) in [#252](https://github.com/illinois/queue/pull/252))
+
 ## v1.0.3
 
 * Add user-facing warning about socket errors to help track down [#241](https://github.com/illinois/queue/issues/241). ([@nwalters512](https://github.com/nwalters512) in [#250](https://github.com/illinois/queue/pull/250))

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -54,7 +54,7 @@ class Header extends React.Component {
     // login page
     const brandLink = user ? (
       <Link route="index" passHref>
-        <NavbarBrand>Queue@Illinois</NavbarBrand>
+        <NavbarBrand aria-label="Queue Home">Queue@Illinois</NavbarBrand>
       </Link>
     ) : (
       <NavbarBrand tag="span">Queue@Illinois</NavbarBrand>
@@ -62,11 +62,13 @@ class Header extends React.Component {
 
     return (
       <Navbar
+        tag="header"
         color="dark"
         dark
         className="mb-3 fixed-top"
         style={styles.navbar}
         expand="sm"
+        aria-label="Main navigation"
       >
         {brandLink}
         {user && (
@@ -75,7 +77,10 @@ class Header extends React.Component {
             <Collapse isOpen={this.state.isOpen} navbar>
               <Nav navbar className="ml-auto">
                 <Link route="userSettings" passHref>
-                  <NavLink className="navbar-text mr-3">
+                  <NavLink
+                    className="navbar-text mr-3"
+                    aria-label="User profile"
+                  >
                     <FontAwesomeIcon icon={faUser} className="mr-2" />
                     {userName}
                   </NavLink>

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -75,7 +75,7 @@ class Header extends React.Component {
           <Fragment>
             <NavbarToggler onClick={() => this.toggle()} />
             <Collapse isOpen={this.state.isOpen} navbar>
-              <Nav navbar className="ml-auto">
+              <Nav navbar className="ml-auto" aria-label="Account tools">
                 <Link route="userSettings" passHref>
                   <NavLink
                     className="navbar-text mr-3"


### PR DESCRIPTION
Implements the accessibility recommendations from #246. I also changed the navbar to be a `<header>` element instead of a `<nav>`, since that seems to be the recommendation: https://www.w3.org/WAI/tutorials/page-structure/regions/. This is also what the Bootstrap docs themselves do.

cc @bhuvy2