### PR TITLE
Improve queue card accessibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ with the current semantic version and the next changes should go under a **[Next
 ## [Next]
 
 * Fix logic for filtering confidential questions. ([@james9909](https://github.com/james9909) in [#257](https://github.com/illinois/queue/pull/257))
+* Improve accessibility of queue cards. ([@nwalters512](https://github.com/nwalters512) in [#255](https://github.com/illinois/queue/pull/255))
 
 ## v1.0.4
 

--- a/src/components/QueueCard.js
+++ b/src/components/QueueCard.js
@@ -9,7 +9,7 @@ import {
 } from '@fortawesome/free-solid-svg-icons'
 import classNames from 'classnames'
 
-import { Router, Link } from '../routes'
+import { Link } from '../routes'
 import ShowForCourseStaff from './ShowForCourseStaff'
 
 const QueueCard = ({ queue, courseName, open, ...rest }) => {
@@ -19,12 +19,6 @@ const QueueCard = ({ queue, courseName, open, ...rest }) => {
     questionCount !== 1 ? 's' : ''
   }`
   const locationText = location || 'No location specified'
-
-  const handleSettings = e => {
-    e.stopPropagation()
-    e.preventDefault()
-    Router.pushRoute('queueSettings', { id: queue.id })
-  }
 
   const title = courseName || queueName
   const accessibilityName = `${courseName} ${queueName}`

--- a/src/components/QueueCard.js
+++ b/src/components/QueueCard.js
@@ -7,8 +7,9 @@ import {
   faQuestionCircle,
   faEyeSlash,
 } from '@fortawesome/free-solid-svg-icons'
+import classNames from 'classnames'
 
-import { Router } from '../routes'
+import { Router, Link } from '../routes'
 import ShowForCourseStaff from './ShowForCourseStaff'
 
 const QueueCard = ({ queue, courseName, open, ...rest }) => {
@@ -26,11 +27,20 @@ const QueueCard = ({ queue, courseName, open, ...rest }) => {
   }
 
   const title = courseName || queueName
+  const accessibilityName = `${courseName} ${queueName}`
+  const cardAccessibilityLabel = `Queue for ${accessibilityName}`
+  const settingsAccessibilityLabel = `${accessibilityName} settings`
   const showQueueNameInBody = !!courseName
+
+  const cardClasses = classNames('queue-card', {
+    'bg-light': !open,
+  })
 
   return (
     <Card
-      className={open ? 'queue-card' : 'closed-queue-card bg-light'}
+      className={cardClasses}
+      role="link"
+      aria-label={cardAccessibilityLabel}
       {...rest}
     >
       <CardBody>
@@ -41,19 +51,20 @@ const QueueCard = ({ queue, courseName, open, ...rest }) => {
             )}
             {title}
           </span>
-          <div>
-            <ShowForCourseStaff courseId={queue.courseId}>
+          <ShowForCourseStaff courseId={queue.courseId}>
+            <Link passHref route="queueSettings" params={{ id: queue.id }}>
               <Button
+                tag="a"
+                role="link"
                 color="secondary"
                 size="sm"
+                aria-label={settingsAccessibilityLabel}
                 outline
-                onClick={handleSettings}
-                onKeyPress={handleSettings}
               >
                 Settings
               </Button>
-            </ShowForCourseStaff>
-          </div>
+            </Link>
+          </ShowForCourseStaff>
         </CardTitle>
         {showQueueNameInBody && (
           <CardSubtitle className="mb-2">
@@ -76,8 +87,7 @@ const QueueCard = ({ queue, courseName, open, ...rest }) => {
         </div>
       </CardBody>
       <style global jsx>{`
-        .queue-card,
-        .closed-queue-card {
+        .queue-card {
           transition: all 200ms;
           cursor: pointer;
         }
@@ -86,6 +96,11 @@ const QueueCard = ({ queue, courseName, open, ...rest }) => {
           box-shadow: 0px 1px 5px 0px rgba(0, 0, 0, 0.2),
             0px 2px 2px 0px rgba(0, 0, 0, 0.14),
             0px 3px 1px -2px rgba(0, 0, 0, 0.12);
+        }
+        .queue-card:focus {
+          transform: none;
+          box-shadow: 0 0 0 0.25rem rgba(108, 117, 125, 0.5);
+          outline: none;
         }
       `}</style>
     </Card>

--- a/src/components/QueueCard.js
+++ b/src/components/QueueCard.js
@@ -52,6 +52,7 @@ const QueueCard = ({ queue, courseName, open, ...rest }) => {
                 role="link"
                 color="secondary"
                 size="sm"
+                onClick={e => e.stopPropagation()}
                 aria-label={settingsAccessibilityLabel}
                 outline
               >

--- a/src/components/QueueCardList.js
+++ b/src/components/QueueCardList.js
@@ -1,6 +1,6 @@
 import React, { Fragment } from 'react'
 import PropTypes from 'prop-types'
-import { Col, Card, CardBody } from 'reactstrap'
+import { Row, Col, Card, CardBody } from 'reactstrap'
 
 import { Router } from '../routes'
 
@@ -40,6 +40,7 @@ const QueueCardList = props => {
       md={{ size: 6 }}
       lg={{ size: 4 }}
       className="mb-3"
+      tag="li"
       {...rest}
     >
       {children}
@@ -54,13 +55,14 @@ const QueueCardList = props => {
 
     const handleQueueKeyPress = (e, id) => {
       if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault()
         handleQueueClick(id)
       }
     }
 
     props.queueIds.sort(queueSorter)
 
-    queues = props.queueIds.map(queueId => {
+    const queueCards = props.queueIds.map(queueId => {
       const queue = props.queues[queueId]
       const courseName = props.courses[queue.courseId].name
       return (
@@ -76,6 +78,11 @@ const QueueCardList = props => {
         </CardCol>
       )
     })
+    queues = (
+      <Row className="equal-height mb-5 queue-card-row" tag="ul">
+        {queueCards}
+      </Row>
+    )
   } else {
     queues = (
       <Col>
@@ -103,6 +110,9 @@ const QueueCardList = props => {
         }
         .row.equal-height .card {
           flex: 1;
+        }
+        .queue-card-row {
+          padding: 0;
         }
       `}</style>
     </Fragment>

--- a/src/pages/course.js
+++ b/src/pages/course.js
@@ -1,7 +1,7 @@
 import React, { Fragment } from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
-import { Container, Row, Card, CardBody, Button } from 'reactstrap'
+import { Container, Card, CardBody, Button } from 'reactstrap'
 import Error from 'next/error'
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'

--- a/src/pages/course.js
+++ b/src/pages/course.js
@@ -126,20 +126,13 @@ class Course extends React.Component {
               </CardBody>
             </Card>
           )}
-          <Row className="equal-height mb-5">
-            <QueueCardListContainer queueIds={openQueueIds} openQueue />
-          </Row>
+          <QueueCardListContainer queueIds={openQueueIds} openQueue />
           <div className="d-flex flex-wrap align-items-center mb-4">
             <h2 className="d-inline-block mb-0 mt-3 mr-auto pr-3">
               Closed Queues
             </h2>
           </div>
-          <Row className="equal-height mb-5">
-            <QueueCardListContainer
-              queueIds={closedQueueIds}
-              openQueue={false}
-            />
-          </Row>
+          <QueueCardListContainer queueIds={closedQueueIds} openQueue={false} />
           <CourseShortCodeInfo course={this.props.course} />
         </Container>
         <style jsx>{`

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -110,102 +110,78 @@ class Index extends React.Component {
       .map(queue => queue.id)
 
     return (
-      <Fragment>
-        <Container>
-          <DevWorkshopAd />
-          <div className="d-flex flex-wrap align-items-center mb-4">
-            <h1 className="display-4 d-inline-block mb-0 mt-3 mr-auto pr-3">
-              Open queues
-            </h1>
-            {this.props.showCreateQueueButton && (
-              <Button
-                color="primary"
-                className="mt-3"
-                onClick={() => this.showCreateQueuePanel(true)}
-              >
-                <FontAwesomeIcon icon={faPlus} className="mr-2" />
-                Create queue
-              </Button>
-            )}
-          </div>
-          {this.state.showCreateQueuePanel && (
-            <Card className="mb-4">
-              <CardBody>
-                <NewQueue
-                  showCourseSelector
-                  onCreateQueue={(queue, courseId) =>
-                    this.createQueue(queue, courseId)
-                  }
-                  onCancel={() => this.showCreateQueuePanel(false)}
-                />
-              </CardBody>
-            </Card>
+      <Container>
+        <DevWorkshopAd />
+        <div className="d-flex flex-wrap align-items-center mb-4">
+          <h1 className="display-4 d-inline-block mb-0 mt-3 mr-auto pr-3">
+            Open queues
+          </h1>
+          {this.props.showCreateQueueButton && (
+            <Button
+              color="primary"
+              className="mt-3"
+              onClick={() => this.showCreateQueuePanel(true)}
+            >
+              <FontAwesomeIcon icon={faPlus} className="mr-2" />
+              Create queue
+            </Button>
           )}
-          <Row className="equal-height mb-4">
-            <QueueCardListContainer
-              queueIds={openQueueIds}
-              showCourseName
-              openQueue
-            />
-          </Row>
-          <div className="d-flex flex-wrap align-items-center mb-4">
-            <h3 className="d-inline-block mb-0 mt-3 mr-auto pr-3">
-              Or, select a course
-            </h3>
-            <ShowForAdmin>
-              <Button
-                color="primary"
-                className="mt-3"
-                onClick={() => this.showCreateCoursePanel(true)}
-              >
-                <FontAwesomeIcon icon={faPlus} className="mr-2" />
-                Create course
-              </Button>
-            </ShowForAdmin>
-          </div>
-          {this.state.showCreateCoursePanel && (
-            <Card className="mb-4">
-              <CardBody>
-                <NewCourse
-                  onCreateCourse={course => this.createCourse(course)}
-                  onCancel={() => this.showCreateCoursePanel(false)}
-                />
-              </CardBody>
-            </Card>
-          )}
-          <div className="mb-1">{courseButtons}</div>
-          <div className="d-flex flex-wrap align-items-center mb-4">
-            <h1 className="display-4 d-inline-block mb-0 mt-3 mr-auto pr-3">
-              Closed queues
-            </h1>
-          </div>
-          <Row className="equal-height mb-4">
-            <QueueCardListContainer
-              queueIds={closedQueueIds}
-              showCourseName
-              openQueue={false}
-            />
-          </Row>
-        </Container>
-        <style global jsx>{`
-          .courses-card {
-            width: 100%;
-            max-width: 500px;
-            margin: auto;
-          }
-          .row.equal-height {
-            display: flex;
-            flex-wrap: wrap;
-          }
-          .row.equal-height > [class*='col-'] {
-            display: flex;
-            flex-direction: column;
-          }
-          .row.equal-height .card {
-            flex: 1;
-          }
-        `}</style>
-      </Fragment>
+        </div>
+        {this.state.showCreateQueuePanel && (
+          <Card className="mb-4">
+            <CardBody>
+              <NewQueue
+                showCourseSelector
+                onCreateQueue={(queue, courseId) =>
+                  this.createQueue(queue, courseId)
+                }
+                onCancel={() => this.showCreateQueuePanel(false)}
+              />
+            </CardBody>
+          </Card>
+        )}
+        <QueueCardListContainer
+          queueIds={openQueueIds}
+          showCourseName
+          openQueue
+        />
+        <div className="d-flex flex-wrap align-items-center mb-4">
+          <h3 className="d-inline-block mb-0 mt-3 mr-auto pr-3">
+            Or, select a course
+          </h3>
+          <ShowForAdmin>
+            <Button
+              color="primary"
+              className="mt-3"
+              onClick={() => this.showCreateCoursePanel(true)}
+            >
+              <FontAwesomeIcon icon={faPlus} className="mr-2" />
+              Create course
+            </Button>
+          </ShowForAdmin>
+        </div>
+        {this.state.showCreateCoursePanel && (
+          <Card className="mb-4">
+            <CardBody>
+              <NewCourse
+                onCreateCourse={course => this.createCourse(course)}
+                onCancel={() => this.showCreateCoursePanel(false)}
+              />
+            </CardBody>
+          </Card>
+        )}
+        <div className="mb-1">{courseButtons}</div>
+        <div className="d-flex flex-wrap align-items-center mb-4">
+          <h1 className="display-4 d-inline-block mb-0 mt-3 mr-auto pr-3">
+            Closed queues
+          </h1>
+        </div>
+        <QueueCardListContainer
+          queueIds={closedQueueIds}
+          showCourseName
+          openQueue={false}
+        />
+      </Container>
     )
   }
 }

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -113,6 +113,7 @@ class Index extends React.Component {
     return (
       <Container>
         <DevWorkshopAd />
+        <StackRebrandingAlert />
         <div className="d-flex flex-wrap align-items-center mb-4">
           <h1 className="display-4 d-inline-block mb-0 mt-3 mr-auto pr-3">
             Open queues

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,7 +1,7 @@
-import React, { Fragment } from 'react'
+import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
-import { Container, Row, Card, CardBody, Button } from 'reactstrap'
+import { Container, Card, CardBody, Button } from 'reactstrap'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faPlus } from '@fortawesome/free-solid-svg-icons'
 


### PR DESCRIPTION
Implements some improvements to queue card accessibility based on #244. Draws some inspiration from [this article](https://inclusive-components.design/cards/).

* Puts queue cards in a `<ul>` list so that screen readers can identify it as a list, announce how many elements it has, etc.
* Add custom styles for `:focus` to improve appearance for sighted keyboard users.
* Mark entire card as a link with a label like "Queue for CS 225 Office Hours".
* Change "Settings" button to an `<a>` so that it's identified as a link; also gives the link an appropriate label like "CS 225 Office Hours settings".

Tested this with Voiceover on Safari and Chrome; tabbing through the list of queues is now a significantly better experience. I'm not sure how to get Voiceover to read other content from the card (e.g. location or number of questions), so I didn't change the markup of those yet since I'm not sure a) if they're ever read or b) how to test them if they are.

cc @bhuvy2
