### PR TITLE
Fix logic for filtering confidential questions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ with the current semantic version and the next changes should go under a **[Next
 
 ## [Next]
 
+* Fix logic for filtering confidential questions. ([@james9909](https://github.com/james9909) in [#257](https://github.com/illinois/queue/pull/257))
+
 ## v1.0.4
 
 * Rebrand to Stack@Illinois. ([@nwalters512](https://github.com/nwalters512) in [#256](https://github.com/illinois/queue/pull/256))

--- a/src/socket/server.js
+++ b/src/socket/server.js
@@ -231,7 +231,7 @@ module.exports = newIo => {
           userAuthzPromise,
         ])
         const { courseId, isConfidential } = queue
-        const isStudent = !isUserStudent(userAuthz, courseId)
+        const isStudent = isUserStudent(userAuthz, courseId)
         let sendCompleteQuestionData = true
         if (isConfidential && isStudent) {
           // All users that shouldn't see confidential information are added


### PR DESCRIPTION
A leftover from a refactor in #233 inverted the logic that determined when to filter questions for confidential queues, causing things to render incorrectly. This should have only affected users of confidential queues.