### PR TITLE
Add debugging for new socket error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ with the current semantic version and the next changes should go under a **[Next
 ## [Next]
 
 * Fix logic for filtering confidential questions. ([@james9909](https://github.com/james9909) in [#257](https://github.com/illinois/queue/pull/257))
+* Add logging for new socket initialization error. ([@nwalters512](https://github.com/nwalters512) in [#258](https://github.com/illinois/queue/pull/258))
 
 ## v1.0.4
 

--- a/src/socket/server.js
+++ b/src/socket/server.js
@@ -218,38 +218,44 @@ module.exports = newIo => {
   queueNamespace = io.of('/queue')
   queueNamespace.on('connection', socket => {
     socket.on('join', async (msg, callback) => {
-      if ('queueId' in msg) {
-        const { queueId } = msg
-        const queuePromise = Queue.findOne({
-          where: {
-            id: queueId,
-          },
-        })
-        const userAuthzPromise = getAuthzForUser(socket.request.user)
-        const [queue, userAuthz] = await Promise.all([
-          queuePromise,
-          userAuthzPromise,
-        ])
-        const { courseId, isConfidential } = queue
-        const isStudent = isUserStudent(userAuthz, courseId)
-        let sendCompleteQuestionData = true
-        if (isConfidential && isStudent) {
-          // All users that shouldn't see confidential information are added
-          // to a "public" version of the room that receives the minimum
-          // possible set of information
-          socket.join(`queue-${queueId}-public`)
-          // Users will also join a specific room for themselves so that they
-          // receive updates about questions being answered, etc.
-          socket.join(`queue-${queueId}-user-${socket.request.user.id}`)
-          sendCompleteQuestionData = false
-        } else {
-          // For non-confidential queues, this room will consider receiving all
-          // updates for all users. For confidential queues, only admins and
-          // course staff will be subscribed to this room
-          socket.join(`queue-${queueId}`)
+      try {
+        if ('queueId' in msg) {
+          const { queueId } = msg
+          const queuePromise = Queue.findOne({
+            where: {
+              id: queueId,
+            },
+          })
+          const userAuthzPromise = getAuthzForUser(socket.request.user)
+          const [queue, userAuthz] = await Promise.all([
+            queuePromise,
+            userAuthzPromise,
+          ])
+          const { courseId, isConfidential } = queue
+          const isStudent = isUserStudent(userAuthz, courseId)
+          let sendCompleteQuestionData = true
+          if (isConfidential && isStudent) {
+            // All users that shouldn't see confidential information are added
+            // to a "public" version of the room that receives the minimum
+            // possible set of information
+            socket.join(`queue-${queueId}-public`)
+            // Users will also join a specific room for themselves so that they
+            // receive updates about questions being answered, etc.
+            socket.join(`queue-${queueId}-user-${socket.request.user.id}`)
+            sendCompleteQuestionData = false
+          } else {
+            // For non-confidential queues, this room will consider receiving all
+            // updates for all users. For confidential queues, only admins and
+            // course staff will be subscribed to this room
+            socket.join(`queue-${queueId}`)
+          }
+          const { id: userId } = socket.request.user
+          sendInitialState(queueId, userId, sendCompleteQuestionData, callback)
         }
-        const { id: userId } = socket.request.user
-        sendInitialState(queueId, userId, sendCompleteQuestionData, callback)
+      } catch (err) {
+        logger.error('failed to initialize socket for message')
+        logger.error(err)
+        logger.error(msg)
       }
     })
   })

--- a/src/util/logger.js
+++ b/src/util/logger.js
@@ -1,13 +1,22 @@
 const { createLogger, transports, format } = require('winston')
+const { inspect } = require('util')
 
-const { combine, colorize, timestamp, align, printf } = format
+const { combine, colorize, timestamp, errors, splat } = format
+
+const outputFormat = format.printf(info => {
+  const formattedMessage =
+    typeof info.message === 'string' ? info.message : inspect(info.message)
+  const message = info.stack || formattedMessage
+  return `${info.timestamp} [${info.level}]: ${message}`
+})
 
 module.exports = createLogger({
   format: combine(
+    errors({ stack: true }),
     colorize(),
     timestamp(),
-    align(),
-    printf(info => `${info.timestamp} [${info.level}]: ${info.message}`)
+    splat(),
+    outputFormat
   ),
   transports: [
     new transports.Console({


### PR DESCRIPTION
We're now seeing a fun new variety of error relating to setting up sockets:

```
Unhandled rejection (promise:  Promise {
 <rejected> TypeError: Cannot destructure property `courseId` of 'undefined' or 'null'.
   at Socket.socket.on (/home/waf/queue/build/socket/server.js:233:46)
   at <anonymous> } , reason:  TypeError: Cannot destructure property `courseId` of 'undefined' or 'null'.
   at Socket.socket.on (/home/waf/queue/build/socket/server.js:233:46)
   at <anonymous> ).
```

This PR adds explicit logging for when that fails to hopefully help trace the problem back to its source.