### PR TITLE
Use transactions to fix socket update errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ with the current semantic version and the next changes should go under a **[Next
 * Fix logic for filtering confidential questions. ([@james9909](https://github.com/james9909) in [#257](https://github.com/illinois/queue/pull/257))
 * Add logging for new socket initialization error. ([@nwalters512](https://github.com/nwalters512) in [#258](https://github.com/illinois/queue/pull/258))
 * Remove unused style tag. ([@nwalters512](https://github.com/nwalters512) in [#259](https://github.com/illinois/queue/pull/259))
+* Fix active staff socket errors. ([@nwalters512](https://github.com/nwalters512) in [#262](https://github.com/illinois/queue/pull/262))
 
 ## v1.0.4
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12194,11 +12194,6 @@
         "bluebird": "^3.5.3"
       }
     },
-    "sequelize-stream": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/sequelize-stream/-/sequelize-stream-1.0.2.tgz",
-      "integrity": "sha1-KdyDykRKs78P5fwSzYeFbaMck7Y="
-    },
     "serialize-javascript": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "redux-thunk": "^2.3.0",
     "reselect": "^4.0.0",
     "sequelize": "^5.1.0",
-    "sequelize-stream": "^1.0.2",
     "socket.io": "^2.2.0",
     "socket.io-client": "^2.2.0",
     "styled-jsx": "^3.2.1",

--- a/src/socket/sequelizeStream.js
+++ b/src/socket/sequelizeStream.js
@@ -1,0 +1,85 @@
+const { Readable } = require('stream')
+
+// The following code is based on https://github.com/joeybaker/sequelize-stream,
+// with the only modification being that we also pass the `options` object from
+// Sequelize. This is important so that we can access the transaction if necessary.
+const PREFIX = 'sequelize-stream'
+const EVENTS = {
+  CREATE: 'create',
+  UPDATE: 'update',
+  DESTROY: 'destroy',
+  // unsupported, just here so we can provide a test case and be alerted if
+  // sequelize fixes this in the future.
+  BULK_DESTROY: 'bulk destroy',
+}
+
+const addHooks = ({ sequelize, stream }) => {
+  sequelize.addHook(
+    'afterCreate',
+    `${PREFIX}-afterCreate`,
+    (instance, options) => {
+      stream.push({ event: EVENTS.CREATE, instance, options })
+    }
+  )
+
+  sequelize.addHook(
+    'afterBulkCreate',
+    `${PREFIX}-afterBulkCreate`,
+    (instances, options) => {
+      instances.forEach(instance => {
+        stream.push({ event: EVENTS.CREATE, instance, options })
+      })
+    }
+  )
+
+  sequelize.addHook(
+    'afterUpdate',
+    `${PREFIX}-afterUpdate`,
+    (instance, options) => {
+      stream.push({ event: EVENTS.UPDATE, instance, options })
+    }
+  )
+
+  sequelize.addHook(
+    'afterBulkUpdate',
+    `${PREFIX}-afterBulkUpdate`,
+    ({ model, attributes }, options) => {
+      // this is a hacky way to get the updated rows
+      const { updatedAt } = attributes
+      return model
+        .findAll({ where: { updatedAt }, transaction: options.transaction })
+        .then(instances => {
+          instances.forEach(instance => {
+            stream.push({ event: EVENTS.UPDATE, instance, options })
+          })
+        })
+    }
+  )
+
+  sequelize.addHook(
+    'afterDestroy',
+    `${PREFIX}-afterDestroy`,
+    (instance, options) => {
+      stream.push({ event: EVENTS.DESTROY, instance, options })
+    }
+  )
+
+  // sequelize doesn't pass the instances to us, so all we can do is emit a
+  // destroy event
+  sequelize.addHook(
+    'afterBulkDestroy',
+    `${PREFIX}-afterBulkDestroy`,
+    options => {
+      stream.push({ event: EVENTS.BULK_DESTROY, options })
+    }
+  )
+}
+
+module.exports = sequelize => {
+  const stream = new Readable({
+    objectMode: true,
+    read() {},
+  })
+  addHooks({ sequelize, stream })
+  return stream
+}


### PR DESCRIPTION
As noted in the [Sequelize docs](http://docs.sequelizejs.com/manual/hooks.html#internal-transactions), Sequelize uses a transaction internally for operations like `findOrCreate`, which is precisely the method that the active staff API uses when adding staff members. I believe this fact is causing #92 - there's a race condition where we try to read a tuple before the transaction that creates it has been committed. This PR modifies the code from `sequelize-stream` to make the `options` object available to event listeners so that we can use `options.transaction` as appropriate.

Closes #92 (just over a year after it was reported!)