### PR TITLE
Rewrite queue page with hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ with the current semantic version and the next changes should go under a **[Next
 * Add logging for new socket initialization error. ([@nwalters512](https://github.com/nwalters512) in [#258](https://github.com/illinois/queue/pull/258))
 * Remove unused style tag. ([@nwalters512](https://github.com/nwalters512) in [#259](https://github.com/illinois/queue/pull/259))
 * Fix active staff socket errors. ([@nwalters512](https://github.com/nwalters512) in [#262](https://github.com/illinois/queue/pull/262))
+* Rewrite queue page with hooks; fix miscellaneous bugs. ([@nwalters512](https://github.com/nwalters512) in [#263](https://github.com/illinois/queue/pull/263))
 
 ## v1.0.4
 

--- a/src/actions/queue.js
+++ b/src/actions/queue.js
@@ -63,7 +63,6 @@ export function createQueue(courseId, queue) {
 /**
  * Fetch a queue
  */
-
 export const fetchQueueRequest = makeActionCreator(
   types.FETCH_QUEUE.REQUEST,
   'queueId'
@@ -88,7 +87,7 @@ export function fetchQueue(queueId) {
       .then(res => dispatch(fetchQueueSuccess(queueId, res.data)))
       .catch(err => {
         console.error(err)
-        dispatch(fetchQueueFailure(queueId, err))
+        return dispatch(fetchQueueFailure(queueId, err))
       })
   }
 }

--- a/src/actions/socket.js
+++ b/src/actions/socket.js
@@ -1,8 +1,6 @@
 import { makeActionCreator } from './util'
 import * as types from '../constants/ActionTypes'
 
-export const setSocketError = makeActionCreator(types.SET_SOCKET_ERROR, 'error')
-
 export const setSocketStatus = makeActionCreator(
   types.SET_SOCKET_STATUS,
   'status'

--- a/src/api/queues.js
+++ b/src/api/queues.js
@@ -104,7 +104,7 @@ router.get(
           },
           required: false,
           include: [User],
-          attributes: ['startTime', 'endTime'],
+          attributes: ['id', 'startTime', 'endTime'],
         },
         {
           model: Question,

--- a/src/components/QueueMessageViewer.js
+++ b/src/components/QueueMessageViewer.js
@@ -110,10 +110,14 @@ const QueueMessageViewer = props => {
 
 QueueMessageViewer.propTypes = {
   queueId: PropTypes.number.isRequired,
-  message: PropTypes.string.isRequired,
+  message: PropTypes.string,
   collapsible: PropTypes.bool.isRequired,
   editable: PropTypes.bool.isRequired,
   onEdit: PropTypes.func.isRequired,
+}
+
+QueueMessageViewer.defaultProps = {
+  message: '',
 }
 
 export default QueueMessageViewer

--- a/src/components/SocketErrorModal.jsx
+++ b/src/components/SocketErrorModal.jsx
@@ -2,8 +2,8 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { Modal, ModalHeader, ModalBody } from 'reactstrap'
 
-const SocketErrorModal = ({ isOpen, toggle, error }) => (
-  <Modal isOpen={isOpen} toggle={toggle}>
+const SocketErrorModal = ({ isOpen }) => (
+  <Modal isOpen={isOpen}>
     <ModalHeader>Socket error</ModalHeader>
     <ModalBody>
       <p>
@@ -14,28 +14,12 @@ const SocketErrorModal = ({ isOpen, toggle, error }) => (
         developers can get in touch with you! In the meantime, please try
         accessing the Queue from another browser or device.
       </p>
-      {error && (
-        <>
-          <p>
-            <b>Please include the below message in your email:</b>
-          </p>
-          <pre>
-            <code>{error}</code>
-          </pre>
-        </>
-      )}
     </ModalBody>
   </Modal>
 )
 
 SocketErrorModal.propTypes = {
   isOpen: PropTypes.bool.isRequired,
-  toggle: PropTypes.func.isRequired,
-  error: PropTypes.string,
-}
-
-SocketErrorModal.defaultProps = {
-  error: null,
 }
 
 export default SocketErrorModal

--- a/src/components/SocketStatusAlert.jsx
+++ b/src/components/SocketStatusAlert.jsx
@@ -24,7 +24,6 @@ const SocketStatusAlert = ({ isOpen, status }) => {
       color = 'danger'
       break
     default:
-      // uhhhhhhhhhh
       return null
   }
   return (
@@ -38,8 +37,11 @@ const SocketStatusAlert = ({ isOpen, status }) => {
 
 SocketStatusAlert.propTypes = {
   isOpen: PropTypes.bool.isRequired,
-  status: PropTypes.oneOf([SOCKET_CONNECTED, SOCKET_CONNECTING, SOCKET_ERROR])
-    .isRequired,
+  status: PropTypes.oneOf([SOCKET_CONNECTED, SOCKET_CONNECTING, SOCKET_ERROR]),
+}
+
+SocketStatusAlert.defaultProps = {
+  status: null,
 }
 
 export default SocketStatusAlert

--- a/src/components/SocketStatusAlert.jsx
+++ b/src/components/SocketStatusAlert.jsx
@@ -5,6 +5,7 @@ import {
   SOCKET_CONNECTED,
   SOCKET_CONNECTING,
   SOCKET_ERROR,
+  SOCKET_STATUS_TYPES,
 } from '../constants/socketStatus'
 
 const SocketStatusAlert = ({ isOpen, status }) => {
@@ -37,7 +38,7 @@ const SocketStatusAlert = ({ isOpen, status }) => {
 
 SocketStatusAlert.propTypes = {
   isOpen: PropTypes.bool.isRequired,
-  status: PropTypes.oneOf([SOCKET_CONNECTED, SOCKET_CONNECTING, SOCKET_ERROR]),
+  status: PropTypes.oneOf(SOCKET_STATUS_TYPES),
 }
 
 SocketStatusAlert.defaultProps = {

--- a/src/components/StaffSidebar.js
+++ b/src/components/StaffSidebar.js
@@ -58,17 +58,11 @@ class StaffSidebar extends React.Component {
     if (this.props.queue) {
       const { removeStaff, queue } = this.props
       const activeStaffIds = queue.activeStaff
-      console.log('queue', queue)
-      console.log('users', this.props.users)
-      console.log('active staff', this.props.activeStaff)
 
       if (activeStaffIds && activeStaffIds.length > 0) {
-        console.log(activeStaffIds)
         staffList = activeStaffIds.map(id => {
           const activeStaffId = id
           const user = this.props.users[this.props.activeStaff[id].user]
-          console.log('USER')
-          console.log(user)
           return (
             <div key={user.id}>
               <StaffMember

--- a/src/config/config.json
+++ b/src/config/config.json
@@ -4,17 +4,12 @@
     "storage": "./dev.sqlite",
     "logging": false
   },
-  "now": {
-    "dialect": "sqlite",
-    "storage": "./dev.sqlite",
-    "logging": false
-  },
   "test": {
     "dialect": "sqlite",
     "storage": ":memory:",
     "logging": false
   },
-  "now2": {
+  "now": {
     "dialect": "sqlite",
     "storage": "/tmp/now.sqlite",
     "logging": false

--- a/src/constants/ActionTypes.js
+++ b/src/constants/ActionTypes.js
@@ -45,5 +45,4 @@ export const REPLACE_ACTIVE_STAFF = 'REPLACE_ACTIVE_STAFF'
 
 /* Actions for socket status */
 export const SET_SOCKET_STATUS = 'SET_SOCKET_STATUS'
-export const SET_SOCKET_ERROR = 'SET_SOCKET_ERROR'
 export const RESET_SOCKET_STATE = 'RESET_SOCKET_STATE'

--- a/src/constants/socketStatus.js
+++ b/src/constants/socketStatus.js
@@ -1,4 +1,10 @@
 export const SOCKET_CONNECTING = 'connecting'
 export const SOCKET_CONNECTED = 'connected'
 export const SOCKET_ERROR = 'error'
-export const SOCKET_CONNECT_FAILED = 'connect_failed'
+export const SOCKET_AUTHENTICATION_ERROR = 'authentication_error'
+export const SOCKET_STATUS_TYPES = [
+  SOCKET_CONNECTING,
+  SOCKET_CONNECTED,
+  SOCKET_ERROR,
+  SOCKET_AUTHENTICATION_ERROR,
+]

--- a/src/pages/queue.js
+++ b/src/pages/queue.js
@@ -39,7 +39,7 @@ import {
   SOCKET_CONNECTING,
   SOCKET_CONNECTED,
   SOCKET_ERROR,
-  SOCKET_CONNECT_FAILED,
+  SOCKET_AUTHENTICATION_ERROR,
 } from '../constants/socketStatus'
 import SocketStatusAlert from '../components/SocketStatusAlert'
 
@@ -96,7 +96,10 @@ const Queue = props => {
       setShowSocketStatus(true)
       return NOOP
     }
-    if (props.socketStatus === SOCKET_ERROR) {
+    if (
+      props.socketStatus === SOCKET_ERROR ||
+      props.socketStatus === SOCKET_AUTHENTICATION_ERROR
+    ) {
       setShowSocketStatus(true)
       return NOOP
     }
@@ -187,7 +190,9 @@ const Queue = props => {
           <QuestionListContainer queueId={props.queueId} />
         </Col>
       </Row>
-      <SocketErrorModal isOpen={props.socketStatus === SOCKET_CONNECT_FAILED} />
+      <SocketErrorModal
+        isOpen={props.socketStatus === SOCKET_AUTHENTICATION_ERROR}
+      />
     </Container>
   )
 }

--- a/src/pages/queue.js
+++ b/src/pages/queue.js
@@ -10,7 +10,6 @@ import {
   CardBody,
   Collapse,
   UncontrolledTooltip,
-  Alert,
 } from 'reactstrap'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faMapMarker, faEyeSlash } from '@fortawesome/free-solid-svg-icons'
@@ -40,6 +39,7 @@ import {
   SOCKET_CONNECTING,
   SOCKET_CONNECTED,
   SOCKET_ERROR,
+  SOCKET_CONNECT_FAILED,
 } from '../constants/socketStatus'
 import SocketStatusAlert from '../components/SocketStatusAlert'
 
@@ -187,10 +187,7 @@ const Queue = props => {
           <QuestionListContainer queueId={props.queueId} />
         </Col>
       </Row>
-      <SocketErrorModal
-        isOpen={!!props.socketError}
-        error={props.socketError}
-      />
+      <SocketErrorModal isOpen={props.socketStatus === SOCKET_CONNECT_FAILED} />
     </Container>
   )
 }
@@ -224,7 +221,6 @@ Queue.propTypes = {
   }),
   pageTransitionReadyToEnter: PropTypes.func,
   socketStatus: PropTypes.string,
-  socketError: PropTypes.string,
 }
 
 Queue.defaultProps = {
@@ -232,7 +228,6 @@ Queue.defaultProps = {
   course: null,
   pageTransitionReadyToEnter: null,
   socketStatus: SOCKET_CONNECTING,
-  socketError: null,
 }
 
 const mapStateToProps = (state, ownProps) => {
@@ -244,7 +239,6 @@ const mapStateToProps = (state, ownProps) => {
     isUserCourseStaff: isUserCourseStaffForQueue(state, ownProps),
     isUserAdmin: isUserAdmin(state, ownProps),
     socketStatus: state.socket.status,
-    socketError: state.socket.error,
   }
 }
 

--- a/src/pages/queue.js
+++ b/src/pages/queue.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState, useEffect } from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import {
@@ -13,7 +13,8 @@ import {
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faMapMarker, faEyeSlash } from '@fortawesome/free-solid-svg-icons'
 
-import { fetchQueue, fetchQueueRequest } from '../actions/queue'
+import { Link } from '../routes'
+import { fetchQueue } from '../actions/queue'
 import { fetchCourse } from '../actions/course'
 import { connectToQueue, disconnectFromQueue } from '../socket/client'
 
@@ -32,144 +33,139 @@ import { isUserCourseStaffForQueue, isUserAdmin } from '../selectors'
 import ConfidentialQueuePanelContainer from '../containers/ConfidentialQueuePanelContainer'
 import SocketErrorModal from '../components/SocketErrorModal'
 import { resetSocketState } from '../actions/socket'
+import { FETCH_QUEUE } from '../constants/ActionTypes'
 
-class Queue extends React.Component {
-  static getInitialProps({ isServer, store, query }) {
-    const queueId = Number.parseInt(query.id, 10)
-    if (isServer) {
-      store.dispatch(fetchQueueRequest(queueId))
-    }
-    return {
-      queueId,
-      isFetchingQueue: isServer,
-    }
-  }
-
-  static pageTransitionDelayEnter = true
-
-  componentDidMount() {
-    this.props.fetchQueue(this.props.queueId).then(action => {
-      if (this.props.pageTransitionReadyToEnter) {
-        this.props.pageTransitionReadyToEnter()
-      }
-      // We won't block the page from showing while we load the course - we'll
-      // simply show the course name as soon as it's available
-      return this.props.fetchCourse(action.queue.courseId)
-    })
-  }
-
-  componentDidUpdate(prevProps) {
-    if (
-      prevProps.isFetchingQueue &&
-      !this.props.isFetchingQueue &&
-      this.props.hasQueue
-    ) {
-      // We have finished fetching the queue and the queue exists (was not a 404)
-      // It's now safe to connect to the websocket
-      connectToQueue(this.props.dispatch, this.props.queueId)
-    }
-  }
-
-  componentWillUnmount() {
-    disconnectFromQueue(this.props.queueId)
-    resetSocketState()
-  }
-
-  render() {
-    const { isFetchingQueue, hasQueue } = this.props
-
-    if (isFetchingQueue) {
-      return null
-    }
-    if (!isFetchingQueue && !hasQueue) {
-      return <Error statusCode={404} />
-    }
-    const locationText = this.props.queue.location || 'No location specified'
-    const confidentialMessage =
-      this.props.isUserCourseStaff || this.props.isUserAdmin
-        ? 'Students'
-        : 'You'
-
-    let queueName = ''
-    const { name } = this.props.queue
-    if (this.props.course) {
-      queueName += `${this.props.course.name} — `
-    }
-    queueName += name
-    return (
-      <Container fluid>
-        <h3>
-          {this.props.queue.isConfidential && (
-            <span>
-              <FontAwesomeIcon
-                icon={faEyeSlash}
-                fixedWidth
-                className="mr-2"
-                id="confidentialIcon"
-              />
-              <UncontrolledTooltip placement="bottom" target="confidentialIcon">
-                This is a confidential queue! {confidentialMessage} won&apos;t
-                be able to see questions from other students.
-              </UncontrolledTooltip>
-            </span>
-          )}
-          {queueName}
-        </h3>
-        <h5 className="mb-3 text-muted">
-          <FontAwesomeIcon icon={faMapMarker} fixedWidth className="mr-2" />
-          {locationText}
-        </h5>
-        <Row>
-          <Col
-            xs={{ size: 12 }}
-            md={{ size: 4 }}
-            lg={{ size: 3 }}
-            className="mb-3 mb-md-0"
-          >
-            <QuestionNotificationsToggle />
-            <ShowForCourseStaff queueId={this.props.queueId}>
-              <QueueStatusToggleContainer queue={this.props.queue} />
-              {!this.props.queue.open && (
-                <DeleteAllQuestionsButtonContainer queue={this.props.queue} />
-              )}
-              <QueueMessageEnabledToggleContainer queue={this.props.queue} />
-            </ShowForCourseStaff>
-            <StaffSidebar queueId={this.props.queueId} />
-          </Col>
-          <Col xs={{ size: 12 }} md={{ size: 8 }} lg={{ size: 9 }}>
-            <Collapse isOpen={this.props.queue.messageEnabled}>
-              <QueueMessageContainer queueId={this.props.queueId} />
-            </Collapse>
-            {this.props.queue.open && (
-              <QuestionPanelContainer queueId={this.props.queueId} />
-            )}
-            {!this.props.queue.open && (
-              <Card className="bg-light mb-3">
-                <CardBody className="text-center">
-                  This queue is closed. Check back later!
-                </CardBody>
-              </Card>
-            )}
-            {this.props.queue.isConfidential &&
-              !this.props.isUserCourseStaff &&
-              !this.props.isUserAdmin && (
-                <ConfidentialQueuePanelContainer queueId={this.props.queueId} />
-              )}
-            <QuestionListContainer queueId={this.props.queueId} />
-          </Col>
-        </Row>
-        <SocketErrorModal
-          isOpen={!!this.props.socketError}
-          error={this.props.socketError}
-        />
-      </Container>
-    )
-  }
+const buildQueueName = (queue, course) => {
+  return (
+    <>
+      {course && (
+        <>
+          <Link route="course" params={{ id: course.id }}>
+            {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
+            <a>{course.name}</a>
+          </Link>
+          <span className="mx-1">/</span>
+        </>
+      )}
+      {queue.name}
+    </>
+  )
 }
 
+const Queue = props => {
+  const [queueLoading, setQueueLoading] = useState(true)
+
+  useEffect(() => {
+    setQueueLoading(true)
+    props.fetchQueue(props.queueId).then(action => {
+      setQueueLoading(false)
+      if (props.pageTransitionReadyToEnter) {
+        props.pageTransitionReadyToEnter()
+      }
+      if (action.type === FETCH_QUEUE.SUCCESS) {
+        props.fetchCourse(action.queue.courseId)
+      }
+    })
+  }, [props.queueId])
+
+  useEffect(() => {
+    connectToQueue(props.dispatch, props.queueId)
+    return () => {
+      disconnectFromQueue(props.queueId)
+      resetSocketState()
+    }
+  }, [props.queueId])
+
+  if (queueLoading) {
+    return null
+  }
+
+  if (!queueLoading && !props.queue) {
+    return <Error statusCode={404} />
+  }
+
+  const queueName = buildQueueName(props.queue, props.course)
+  const locationText = props.queue.location || 'No location specified'
+  const confidentialMessage =
+    props.isUserCourseStaff || props.isUserAdmin ? 'Students' : 'You'
+  return (
+    <Container fluid>
+      <h3>
+        {props.queue.isConfidential && (
+          <span>
+            <FontAwesomeIcon
+              icon={faEyeSlash}
+              fixedWidth
+              className="mr-2"
+              id="confidentialIcon"
+            />
+            <UncontrolledTooltip placement="bottom" target="confidentialIcon">
+              This is a confidential queue! {confidentialMessage} won&apos;t be
+              able to see questions from other students.
+            </UncontrolledTooltip>
+          </span>
+        )}
+        {queueName}
+      </h3>
+      <h5 className="mb-3 text-muted">
+        <FontAwesomeIcon icon={faMapMarker} fixedWidth className="mr-2" />
+        {locationText}
+      </h5>
+      <Row>
+        <Col
+          xs={{ size: 12 }}
+          md={{ size: 4 }}
+          lg={{ size: 3 }}
+          className="mb-3 mb-md-0"
+        >
+          <QuestionNotificationsToggle />
+          <ShowForCourseStaff queueId={props.queueId}>
+            <QueueStatusToggleContainer queue={props.queue} />
+            {!props.queue.open && (
+              <DeleteAllQuestionsButtonContainer queue={props.queue} />
+            )}
+            <QueueMessageEnabledToggleContainer queue={props.queue} />
+          </ShowForCourseStaff>
+          <StaffSidebar queueId={props.queueId} />
+        </Col>
+        <Col xs={{ size: 12 }} md={{ size: 8 }} lg={{ size: 9 }}>
+          <Collapse isOpen={props.queue.messageEnabled}>
+            <QueueMessageContainer queueId={props.queueId} />
+          </Collapse>
+          {props.queue.open && (
+            <QuestionPanelContainer queueId={props.queueId} />
+          )}
+          {!props.queue.open && (
+            <Card className="bg-light mb-3">
+              <CardBody className="text-center">
+                This queue is closed. Check back later!
+              </CardBody>
+            </Card>
+          )}
+          {props.queue.isConfidential &&
+            !props.isUserCourseStaff &&
+            !props.isUserAdmin && (
+              <ConfidentialQueuePanelContainer queueId={props.queueId} />
+            )}
+          <QuestionListContainer queueId={props.queueId} />
+        </Col>
+      </Row>
+      <SocketErrorModal
+        isOpen={!!props.socketError}
+        error={props.socketError}
+      />
+    </Container>
+  )
+}
+
+Queue.getInitialProps = async ({ query }) => {
+  const queueId = Number.parseInt(query.id, 10)
+  return { queueId }
+}
+
+Queue.pageTransitionDelayEnter = true
+
 Queue.propTypes = {
-  isFetchingQueue: PropTypes.bool.isRequired,
-  hasQueue: PropTypes.bool.isRequired,
   fetchQueue: PropTypes.func.isRequired,
   fetchCourse: PropTypes.func.isRequired,
   queueId: PropTypes.number.isRequired,
@@ -204,9 +200,6 @@ const mapStateToProps = (state, ownProps) => {
   const queue = state.queues.queues[ownProps.queueId]
   const course = queue && state.courses.courses[queue.courseId]
   return {
-    isFetchingQueue: state.queues.isFetching,
-    hasQueue: !!queue,
-    hasCourse: !!course,
     queue,
     course,
     isUserCourseStaff: isUserCourseStaffForQueue(state, ownProps),

--- a/src/reducers/queues.js
+++ b/src/reducers/queues.js
@@ -100,8 +100,6 @@ function addActiveStaffToQueue(state, queueId, activeStaffId) {
   return newState
 }
 
-// We need to extract the queues from
-
 const queues = (state = defaultState, action) => {
   switch (action.type) {
     case FETCH_COURSE.REQUEST: {
@@ -117,8 +115,12 @@ const queues = (state = defaultState, action) => {
         queues: {
           ...state.queues,
           ...action.course.queues.reduce((obj, item) => {
+            const newQueue = normalizeQueue(item)
+            // We'll merge in any new info about this queue but keep existing
+            // info, since the queue models returned in course requests aren't
+            // complete
             // eslint-disable-next-line no-param-reassign
-            obj[item.id] = normalizeQueue(item)
+            obj[item.id] = { ...state.queues[item.id], ...newQueue }
             return obj
           }, {}),
         },

--- a/src/reducers/queues.js
+++ b/src/reducers/queues.js
@@ -28,8 +28,6 @@ const defaultState = {
 
 function normalizeQueue(queue) {
   const normalized = normalizeQueueHelper(queue)
-  console.log('original queue', queue)
-  console.log('normalized queue', normalized)
   return normalized.entities.queues[normalized.result]
 }
 

--- a/src/reducers/socket.js
+++ b/src/reducers/socket.js
@@ -1,12 +1,7 @@
-import {
-  SET_SOCKET_STATUS,
-  SET_SOCKET_ERROR,
-  RESET_SOCKET_STATE,
-} from '../constants/ActionTypes'
+import { SET_SOCKET_STATUS, RESET_SOCKET_STATE } from '../constants/ActionTypes'
 
 const defaultState = {
   status: null,
-  error: null,
 }
 
 const socket = (state = defaultState, action) => {
@@ -15,11 +10,6 @@ const socket = (state = defaultState, action) => {
       return {
         ...state,
         status: action.status,
-      }
-    case SET_SOCKET_ERROR:
-      return {
-        ...state,
-        error: action.error,
       }
     case RESET_SOCKET_STATE:
       return {

--- a/src/socket/client.js
+++ b/src/socket/client.js
@@ -15,10 +15,10 @@ import { normalizeActiveStaff } from '../reducers/normalize'
 import { baseUrl } from '../util'
 import { setSocketStatus } from '../actions/socket'
 import {
-  SOCKET_CONNECT_FAILED,
   SOCKET_ERROR,
   SOCKET_CONNECTING,
   SOCKET_CONNECTED,
+  SOCKET_AUTHENTICATION_ERROR,
 } from '../constants/socketStatus'
 
 const socketOpts = {
@@ -64,12 +64,12 @@ export const connectToQueue = (dispatch, queueId) => {
       dispatch(replaceActiveStaff(queueId, activeStaff))
     })
   })
-  socket.on('connect_failed', err => {
-    dispatch(setSocketStatus(SOCKET_CONNECT_FAILED))
-    console.error(err)
-  })
   socket.on('error', err => {
-    dispatch(setSocketStatus(SOCKET_ERROR))
+    if (err === 'Authentication error') {
+      dispatch(setSocketStatus(SOCKET_AUTHENTICATION_ERROR))
+    } else {
+      dispatch(setSocketStatus(SOCKET_ERROR))
+    }
     console.error(err)
   })
   socket.on('reconnecting', () => {

--- a/src/socket/client.js
+++ b/src/socket/client.js
@@ -13,7 +13,7 @@ import {
 import { replaceActiveStaff } from '../actions/activeStaff'
 import { normalizeActiveStaff } from '../reducers/normalize'
 import { baseUrl } from '../util'
-import { setSocketError, setSocketStatus } from '../actions/socket'
+import { setSocketStatus } from '../actions/socket'
 import {
   SOCKET_CONNECT_FAILED,
   SOCKET_ERROR,
@@ -59,36 +59,27 @@ export const connectToQueue = (dispatch, queueId) => {
   queueSockets[queueId] = socket
   socket.on('connect', () => {
     socket.emit('join', { queueId }, ({ questions, activeStaff }) => {
+      dispatch(setSocketStatus(SOCKET_CONNECTED))
       dispatch(replaceQuestions(queueId, questions))
       dispatch(replaceActiveStaff(queueId, activeStaff))
     })
   })
   socket.on('connect_failed', err => {
     dispatch(setSocketStatus(SOCKET_CONNECT_FAILED))
-    dispatch(setSocketError(err))
     console.error(err)
   })
   socket.on('error', err => {
     dispatch(setSocketStatus(SOCKET_ERROR))
-    dispatch(setSocketError(err))
     console.error(err)
-    console.error('error!')
   })
   socket.on('reconnecting', () => {
     dispatch(setSocketStatus(SOCKET_CONNECTING))
-    console.log('reconnecting...')
   })
-  socket.on('reconnect', attempt => {
+  socket.on('reconnect', () => {
     dispatch(setSocketStatus(SOCKET_CONNECTED))
-    console.log(`reconnection successful on attempt ${attempt}`)
   })
   socket.on('reconnect_failed', () => {
     dispatch(setSocketStatus(SOCKET_ERROR))
-    console.log('reconnect failed')
-  })
-  socket.on('connect', () => {
-    dispatch(setSocketStatus(SOCKET_CONNECTED))
-    console.log('connect!')
   })
   socket.on('question:create', ({ question }) =>
     handleQuestionCreate(dispatch, queueId, question)

--- a/src/socket/server.js
+++ b/src/socket/server.js
@@ -238,6 +238,10 @@ module.exports = newIo => {
             queuePromise,
             userAuthzPromise,
           ])
+          if (!queue) {
+            // User tried to connect to a non-existent queue
+            return
+          }
           const { courseId, isConfidential } = queue
           const isStudent = isUserStudent(userAuthz, courseId)
           let sendCompleteQuestionData = true

--- a/src/socket/server.js
+++ b/src/socket/server.js
@@ -214,7 +214,7 @@ module.exports = newIo => {
     if (!user) {
       console.error('failed to authenticate socket')
       console.error(`jwt cookie present? ${!!jwtCookie}`)
-      next(new Error('Could not authenticate socket connection'))
+      next(new Error('Authentication error'))
     } else {
       // eslint-disable-next-line no-param-reassign
       socket.request.user = user


### PR DESCRIPTION
~My hope is that this rewrite will help eliminate the 404s we've been seeing at random. My best guess (or, hunch, really) as to why it's happening is a race condition of some kind, which hooks are better at avoiding. We also explicitly maintain our own loading state in the component. Again, this is just a hunch, and we'll have to see if the anecdotal reports of 404s stop after this.~

Turns out my initial hunch was totally wrong. Eddie figured out how to reproduce the 404 bug:

* View a queue on Safari on an iPhone
* Lock the device
* Unlock the device

It appears as though Safari kills socket connections when Safari isn't in the foreground. When that would happen, we'd get an error event, which (due to my bad error handling) would cause another error. That error would get picked up by React and rendered as our custom error page by Next.js. Unfortunately, our custom error page didn't work well for this use case, because it would default to showing a misleading 404 if a status code wasn't present on the error (which it wasn't, in this case).

So, this PR does a few things to address these issues:

* Properly handles websocket errors
* Reports websocket state to users (reconnecting, connected, failed)
* Renders appropriate error message for non-HTTP-status errors

Given the context of the original problem, would be awesome if people have iOS devices to test with.

Also fixes or enhances a few other things:

* Fixes a regression introduced in #233 where the `id`s of `activeStaff` models weren't being included in the "get queue" response; adds test to prevent future regressions
* Changes how course name is displayed on queue pages, which now serves as a link to the appropriate course
* Limits socket reconnection attempts to 5
* Explicitly handle socket authentication failures separately from normal socket errors.
