### PR TITLE
Rewrite queue settings page with hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ with the current semantic version and the next changes should go under a **[Next
 * Add logging for new socket initialization error. ([@nwalters512](https://github.com/nwalters512) in [#258](https://github.com/illinois/queue/pull/258))
 * Remove unused style tag. ([@nwalters512](https://github.com/nwalters512) in [#259](https://github.com/illinois/queue/pull/259))
 * Fix active staff socket errors. ([@nwalters512](https://github.com/nwalters512) in [#262](https://github.com/illinois/queue/pull/262))
+* Rewrite queue setting page with hooks to fix bug with admission control "Update" button. ([@nwalters512](https://github.com/nwalters512) in [#264](https://github.com/illinois/queue/pull/264))
 
 ## v1.0.4
 


### PR DESCRIPTION
Similar to #263 - fixes an issue when navigating to settings from the homepage where the queue that was already in the Redux store was missing some of the properties needed by the queue settings page. This manifested as the "Update" button for admission control being active even though the user hadn't made any changes yet. Hooks simply made it easier to properly manage state + the `queueId` prop changing.