### PR TITLE
Fix missing question attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ with the current semantic version and the next changes should go under a **[Next
 
 * Add page for admin management. ([@nwalters512](https://github.com/nwalters512) in [#265](https://github.com/illinois/queue/pull/265))
 * Update all dependencies. ([@nwalters512](https://github.com/nwalters512) in [#267](https://github.com/illinois/queue/pull/267))
+* Fix attributes missing from the GET queue endpoint. ([@james9909](https://github.com/james9909) in [#268](https://github.com/illinois/queue/pull/268))
 
 ## v1.0.5
 

--- a/src/api/queues.js
+++ b/src/api/queues.js
@@ -104,7 +104,6 @@ router.get(
           },
           required: false,
           include: [User],
-          attributes: ['id', 'startTime', 'endTime'],
         },
         {
           model: Question,
@@ -112,16 +111,6 @@ router.get(
           where: {
             dequeueTime: null,
           },
-          attributes: [
-            'id',
-            'name',
-            'topic',
-            'beingAnswered',
-            'answerStartTime',
-            'enqueueTime',
-            'dequeueTime',
-            'askedById',
-          ],
         },
       ],
       order: [[Question, 'id', 'ASC']],

--- a/src/api/queues.test.js
+++ b/src/api/queues.test.js
@@ -95,6 +95,8 @@ describe('Queues API', () => {
       expect(res5.body.questions[0].askedBy.netid).toBe(username)
       expect(res5.body.questions[0]).toHaveProperty('answeredBy')
       expect(res5.body.questions[0].answeredBy.name).toBe('241 Staff')
+      expect(res5.body.questions[0].location).toBe('b')
+      expect(res5.body.questions[0].topic).toBe('c')
       expect(res5.body).toHaveProperty('activeStaff')
       expect(res5.body.activeStaff).toHaveLength(1)
       expect(res5.body.activeStaff[0]).toHaveProperty('id')


### PR DESCRIPTION
#233 added an explicit list of attributes to include for joined models in the GET queue endpoint. This change was introduced as a workaround to https://github.com/sequelize/sequelize/issues/10399, but failed to properly include every necessary attribute. 
`sequelize` v5.2.13 fixed the original issue, so we can revert this behavior.