### PR TITLE
Fix sequelize stream handling of bulk updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ with the current semantic version and the next changes should go under a **[Next
 
 ## [Next]
 
+* Fix sequelize stream handling of bulk updates. ([@nwalters512](https://github.com/nwalters512) in [#270](https://github.com/illinois/queue/pull/270))
+
 ## v1.1.0
 
 * Add page for admin management. ([@nwalters512](https://github.com/nwalters512) in [#265](https://github.com/illinois/queue/pull/265))

--- a/src/reducers/questions.js
+++ b/src/reducers/questions.js
@@ -69,7 +69,7 @@ const questions = (state = defaultState, action) => {
     case DELETE_ALL_QUESTIONS.SUCCESS: {
       return {
         ...state,
-        questions: [],
+        questions: {},
       }
     }
     case REPLACE_QUESTIONS: {

--- a/src/socket/sequelizeStream.js
+++ b/src/socket/sequelizeStream.js
@@ -40,21 +40,18 @@ const addHooks = ({ sequelize, stream }) => {
     }
   )
 
-  sequelize.addHook(
-    'afterBulkUpdate',
-    `${PREFIX}-afterBulkUpdate`,
-    ({ model, attributes }, options) => {
-      // this is a hacky way to get the updated rows
-      const { updatedAt } = attributes
-      return model
-        .findAll({ where: { updatedAt }, transaction: options.transaction })
-        .then(instances => {
-          instances.forEach(instance => {
-            stream.push({ event: EVENTS.UPDATE, instance, options })
-          })
+  sequelize.addHook('afterBulkUpdate', `${PREFIX}-afterBulkUpdate`, options => {
+    // this is a hacky way to get the updated rows
+    const { model, attributes } = options
+    const { updatedAt } = attributes
+    return model
+      .findAll({ where: { updatedAt }, transaction: options.transaction })
+      .then(instances => {
+        instances.forEach(instance => {
+          stream.push({ event: EVENTS.UPDATE, instance, options })
         })
-    }
-  )
+      })
+  })
 
   sequelize.addHook(
     'afterDestroy',


### PR DESCRIPTION
I assumed the wrong number of arguments for the `afterBulkUpdate` callback in @262. This fixes that. Also fixes an issue in the questions reducer that I discovered while fixing this problem.

Closes #269 