### PR TITLE
Refine dark mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ with the current semantic version and the next changes should go under a **[Next
 
 ## [Next]
 
+* Refine dark mode: better styles, new Bootstrap colors, and a custom select component. ([@nwalters512](https://github.com/nwalters512) in [#279](https://github.com/illinois/queue/pull/279))
+
 ## v1.2.0
 
 * Fix sequelize stream handling of bulk updates. ([@nwalters512](https://github.com/nwalters512) in [#270](https://github.com/illinois/queue/pull/270))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1171,6 +1171,62 @@
         "minimist": "^1.2.0"
       }
     },
+    "@emotion/babel-utils": {
+      "version": "0.6.10",
+      "resolved": "https://registry.npmjs.org/@emotion/babel-utils/-/babel-utils-0.6.10.tgz",
+      "integrity": "sha512-/fnkM/LTEp3jKe++T0KyTszVGWNKPNOUJfjNKLO17BzQ6QPxgbg3whayom1Qr2oLFH3V92tDymU+dT5q676uow==",
+      "requires": {
+        "@emotion/hash": "^0.6.6",
+        "@emotion/memoize": "^0.6.6",
+        "@emotion/serialize": "^0.9.1",
+        "convert-source-map": "^1.5.1",
+        "find-root": "^1.1.0",
+        "source-map": "^0.7.2"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.7.3",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ=="
+        }
+      }
+    },
+    "@emotion/hash": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.6.6.tgz",
+      "integrity": "sha512-ojhgxzUHZ7am3D2jHkMzPpsBAiB005GF5YU4ea+8DNPybMk01JJUM9V9YRlF/GE95tcOm8DxQvWA2jq19bGalQ=="
+    },
+    "@emotion/memoize": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.6.6.tgz",
+      "integrity": "sha512-h4t4jFjtm1YV7UirAFuSuFGyLa+NNxjdkq6DpFLANNQY5rHueFZHVY+8Cu1HYVP6DrheB0kv4m5xPjo7eKT7yQ=="
+    },
+    "@emotion/serialize": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-0.9.1.tgz",
+      "integrity": "sha512-zTuAFtyPvCctHBEL8KZ5lJuwBanGSutFEncqLn/m9T1a6a93smBStK+bZzcNPgj4QS8Rkw9VTwJGhRIUVO8zsQ==",
+      "requires": {
+        "@emotion/hash": "^0.6.6",
+        "@emotion/memoize": "^0.6.6",
+        "@emotion/unitless": "^0.6.7",
+        "@emotion/utils": "^0.8.2"
+      }
+    },
+    "@emotion/stylis": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.7.1.tgz",
+      "integrity": "sha512-/SLmSIkN13M//53TtNxgxo57mcJk/UJIDFRKwOiLIBEyBHEcipgR6hNMQ/59Sl4VjCJ0Z/3zeAZyvnSLPG/1HQ=="
+    },
+    "@emotion/unitless": {
+      "version": "0.6.7",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.6.7.tgz",
+      "integrity": "sha512-Arj1hncvEVqQ2p7Ega08uHLr1JuRYBuO5cIvcA+WWEQ5+VmkOE3ZXzl04NbQxeQpWX78G7u6MqxKuNX3wvYZxg=="
+    },
+    "@emotion/utils": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.8.2.tgz",
+      "integrity": "sha512-rLu3wcBWH4P5q1CGoSSH/i9hrXs7SlbRLkoq9IGuoPYNGQvDJ3pt/wmOM+XgYjIDRMVIdkUWt0RsfzF50JfnCw=="
+    },
     "@fortawesome/fontawesome-common-types": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.17.tgz",
@@ -2580,6 +2636,40 @@
         "object.assign": "^4.1.0"
       }
     },
+    "babel-plugin-emotion": {
+      "version": "9.2.11",
+      "resolved": "https://registry.npmjs.org/babel-plugin-emotion/-/babel-plugin-emotion-9.2.11.tgz",
+      "integrity": "sha512-dgCImifnOPPSeXod2znAmgc64NhaaOjGEHROR/M+lmStb3841yK1sgaDYAYMnlvWNz8GnpwIPN0VmNpbWYZ+VQ==",
+      "requires": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "@emotion/babel-utils": "^0.6.4",
+        "@emotion/hash": "^0.6.2",
+        "@emotion/memoize": "^0.6.1",
+        "@emotion/stylis": "^0.7.0",
+        "babel-plugin-macros": "^2.0.0",
+        "babel-plugin-syntax-jsx": "^6.18.0",
+        "convert-source-map": "^1.5.0",
+        "find-root": "^1.1.0",
+        "mkdirp": "^0.5.1",
+        "source-map": "^0.5.7",
+        "touch": "^2.0.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+        },
+        "touch": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/touch/-/touch-2.0.2.tgz",
+          "integrity": "sha512-qjNtvsFXTRq7IuMLweVgFxmEuQ6gLbRs2jQxL80TtZ31dEKWYIxRXquij6w6VimyDek5hD3PytljHmEtAs2u0A==",
+          "requires": {
+            "nopt": "~1.0.10"
+          }
+        }
+      }
+    },
     "babel-plugin-istanbul": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-5.1.0.tgz",
@@ -2643,6 +2733,59 @@
       "dev": true,
       "requires": {
         "@types/babel__traverse": "^7.0.6"
+      }
+    },
+    "babel-plugin-macros": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.5.1.tgz",
+      "integrity": "sha512-xN3KhAxPzsJ6OQTktCanNpIFnnMsCV+t8OloKxIL72D6+SUZYFn9qfklPgef5HyyDtzYZqqb+fs1S12+gQY82Q==",
+      "requires": {
+        "@babel/runtime": "^7.4.2",
+        "cosmiconfig": "^5.2.0",
+        "resolve": "^1.10.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.4.3",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.3.tgz",
+          "integrity": "sha512-9lsJwJLxDh/T3Q3SZszfWOTkk3pHbkmH+3KY+zwIDmsNlxsumuhS2TH3NIpktU4kNvfzy+k3eLT7aTJSPTo0OA==",
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        },
+        "cosmiconfig": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.0.tgz",
+          "integrity": "sha512-nxt+Nfc3JAqf4WIWd0jXLjTJZmsPLrA9DDc4nRw2KFJQJK7DNooqSXrNI7tzLG50CF8axczly5UV929tBmh/7g==",
+          "requires": {
+            "import-fresh": "^2.0.0",
+            "is-directory": "^0.3.1",
+            "js-yaml": "^3.13.0",
+            "parse-json": "^4.0.0"
+          }
+        },
+        "import-fresh": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
+          "integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
+          "requires": {
+            "caller-path": "^2.0.0",
+            "resolve-from": "^3.0.0"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.2",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
+          "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
+        },
+        "resolve": {
+          "version": "1.10.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
+          "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
+        }
       }
     },
     "babel-plugin-react-require": {
@@ -3695,7 +3838,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
       "integrity": "sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=",
-      "dev": true,
       "requires": {
         "callsites": "^2.0.0"
       },
@@ -3703,8 +3845,7 @@
         "callsites": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
-          "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
-          "dev": true
+          "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA="
         }
       }
     },
@@ -3712,7 +3853,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-2.0.0.tgz",
       "integrity": "sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=",
-      "dev": true,
       "requires": {
         "caller-callsite": "^2.0.0"
       }
@@ -4427,6 +4567,20 @@
         "elliptic": "^6.0.0"
       }
     },
+    "create-emotion": {
+      "version": "9.2.12",
+      "resolved": "https://registry.npmjs.org/create-emotion/-/create-emotion-9.2.12.tgz",
+      "integrity": "sha512-P57uOF9NL2y98Xrbl2OuiDQUZ30GVmASsv5fbsjF4Hlraip2kyAvMm+2PoYUvFFw03Fhgtxk3RqZSm2/qHL9hA==",
+      "requires": {
+        "@emotion/hash": "^0.6.2",
+        "@emotion/memoize": "^0.6.1",
+        "@emotion/stylis": "^0.7.0",
+        "@emotion/unitless": "^0.6.2",
+        "csstype": "^2.5.2",
+        "stylis": "^3.5.0",
+        "stylis-rule-sheet": "^0.0.10"
+      }
+    },
     "create-error-class": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
@@ -4583,6 +4737,11 @@
       "requires": {
         "cssom": "0.3.x"
       }
+    },
+    "csstype": {
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.4.tgz",
+      "integrity": "sha512-lAJUJP3M6HxFXbqtGRc0iZrdyeN+WzOWeY0q/VnFzI+kqVrYIzC7bWlKqCW7oCIdzoPkvfp82EVvrTlQ8zsWQg=="
     },
     "currently-unhandled": {
       "version": "0.4.1",
@@ -5004,6 +5163,15 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
       "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
+    },
+    "emotion": {
+      "version": "9.2.12",
+      "resolved": "https://registry.npmjs.org/emotion/-/emotion-9.2.12.tgz",
+      "integrity": "sha512-hcx7jppaI8VoXxIWEhxpDW7I+B4kq9RNzQLmsrF6LY8BGKqe2N+gFAQr0EfuFucFlPs2A9HM4+xNj4NeqEWIOQ==",
+      "requires": {
+        "babel-plugin-emotion": "^9.2.11",
+        "create-emotion": "^9.2.12"
+      }
     },
     "enabled": {
       "version": "1.0.2",
@@ -6235,6 +6403,11 @@
       "resolved": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz",
       "integrity": "sha1-Z101iyyjiS15Whq0cjL4tuLg3eQ=",
       "dev": true
+    },
+    "find-root": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng=="
     },
     "find-up": {
       "version": "2.1.0",
@@ -9936,6 +10109,11 @@
         }
       }
     },
+    "memoize-one": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.0.4.tgz",
+      "integrity": "sha512-P0z5IeAH6qHHGkJIXWw0xC2HNEgkx/9uWWBQw64FJj3/ol14VYdfVGWWr0fXfjhhv3TKVIqUq65os6O4GUNksA=="
+    },
     "memory-fs": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
@@ -10940,7 +11118,6 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
       "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
-      "dev": true,
       "requires": {
         "abbrev": "1"
       }
@@ -12144,7 +12321,6 @@
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
       "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
-      "dev": true,
       "requires": {
         "performance-now": "^2.1.0"
       }
@@ -12336,6 +12512,14 @@
       "resolved": "https://registry.npmjs.org/react-hanger/-/react-hanger-1.2.0.tgz",
       "integrity": "sha512-YKMFa4wkWb8pvsxSX9F6atEpsvxfddbfyIv5TmReYs/0oWOZrGIYmVY95kQOX0bnsyy3xRSnjyv62+uZqzZrlQ=="
     },
+    "react-input-autosize": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/react-input-autosize/-/react-input-autosize-2.2.1.tgz",
+      "integrity": "sha512-3+K4CD13iE4lQQ2WlF8PuV5htfmTRLH6MDnfndHM6LuBRszuXnuyIfE7nhSKt8AzRBZ50bu0sAhkNMeS5pxQQA==",
+      "requires": {
+        "prop-types": "^15.5.8"
+      }
+    },
     "react-is": {
       "version": "16.8.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.1.tgz",
@@ -12443,6 +12627,20 @@
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
           "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
         }
+      }
+    },
+    "react-select": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/react-select/-/react-select-2.4.3.tgz",
+      "integrity": "sha512-cmxNaiHpviRYkojeW9rGEUJ4jpX7QTmPe2wcscwA4d1lStzw/cJtr4ft5H2O/YhfpkrcwaLghu3XmEYdXhBo8Q==",
+      "requires": {
+        "classnames": "^2.2.5",
+        "emotion": "^9.1.2",
+        "memoize-one": "^5.0.0",
+        "prop-types": "^15.6.0",
+        "raf": "^3.4.0",
+        "react-input-autosize": "^2.2.1",
+        "react-transition-group": "^2.2.1"
       }
     },
     "react-switch": {

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "react-markdown": "^4.0.6",
     "react-moment": "^0.9.2",
     "react-redux": "^7.0.1",
+    "react-select": "^2.4.3",
     "react-switch": "^4.1.0",
     "react-toastify": "^5.0.1",
     "react-transition-group": "^2.9.0",

--- a/src/components/NewQueue.js
+++ b/src/components/NewQueue.js
@@ -119,7 +119,7 @@ class NewQueue extends React.Component {
               Course
             </Label>
             <Col sm={9}>
-              <Input
+              <CustomInput
                 type="select"
                 name="course"
                 id="course"
@@ -131,7 +131,7 @@ class NewQueue extends React.Component {
                   Select a course
                 </option>
                 {courseOptions}
-              </Input>
+              </CustomInput>
               <FormFeedback>{this.state.fieldErrors.course}</FormFeedback>
             </Col>
           </FormGroup>

--- a/src/components/NewQueue.js
+++ b/src/components/NewQueue.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import PropTypes from 'prop-types'
 import {
   Col,
@@ -11,6 +11,7 @@ import {
   Input,
   Button,
 } from 'reactstrap'
+import { useInput, useBoolean } from 'react-hanger'
 import { connect } from 'react-redux'
 import classnames from 'classnames'
 
@@ -19,234 +20,186 @@ import { mapObjectToArray } from '../util'
 
 const isInvalid = error => error !== undefined && error !== ''
 
-class NewQueue extends React.Component {
-  constructor(props) {
-    super(props)
+const NewQueue = props => {
+  const [course, setCourse] = useState(null)
+  const name = useInput('')
+  const location = useInput('')
+  const fixedLocation = useBoolean(false)
+  const isConfidential = useBoolean(false)
+  const [fieldErrors, setFieldErrors] = useState({})
+  const { courses, user, showCourseSelector } = props
 
-    this.state = {
-      course: 'none',
-      name: '',
-      location: '',
-      fixedLocation: false,
-      isConfidential: false,
-      fieldErrors: {},
-    }
-
-    this.handleInputChange = this.handleInputChange.bind(this)
-    this.handleSubmit = this.handleSubmit.bind(this)
-    this.handleKeyPress = this.handleKeyPress.bind(this)
-  }
-
-  handleKeyPress(e) {
-    if (e.key === 'Enter') {
-      this.handleSubmit()
-    }
-  }
-
-  handleInputChange(event) {
-    if (event.target.type === 'checkbox') {
-      this.setState({
-        [event.target.name]: event.target.checked,
-      })
-    } else {
-      this.setState({
-        [event.target.name]: event.target.value,
-      })
-    }
-  }
-
-  handleSubmit() {
-    let valid = true
-    const fieldErrors = {}
+  const handleSubmit = () => {
+    const currentFieldErrors = {}
 
     // Only validate the course if the course selector is shown
-    if (this.props.showCourseSelector && this.state.course === 'none') {
-      valid = false
-      fieldErrors.course = 'You must select a course'
+    if (props.showCourseSelector && course === null) {
+      currentFieldErrors.course = 'You must select a course'
     }
 
-    if (!this.state.name) {
-      valid = false
-      fieldErrors.name = 'You must name this queue'
+    if (!name.value) {
+      currentFieldErrors.name = 'You must name this queue'
     }
 
-    if (this.state.fixedLocation && !this.state.location) {
-      valid = false
-      fieldErrors.location =
+    if (fixedLocation.value && !location.value) {
+      currentFieldErrors.location =
         'You must set a location for a fixed-location queue'
     }
 
-    if (!valid) {
-      this.setState({ fieldErrors })
+    if (Object.keys(currentFieldErrors).length > 0) {
+      setFieldErrors(currentFieldErrors)
       return
     }
 
     const queue = {
-      name: this.state.name,
-      location: this.state.location,
-      fixedLocation: this.state.fixedLocation,
-      isConfidential: this.state.isConfidential,
+      name: name.value,
+      location: location.value,
+      fixedLocation: fixedLocation.value,
+      isConfidential: isConfidential.value,
     }
 
-    let courseId
-    if (this.state.course) {
-      courseId = Number.parseInt(this.state.course, 10)
-    }
+    const courseId = course && course.value
 
-    this.props.onCreateQueue(queue, courseId)
+    props.onCreateQueue(queue, courseId)
   }
 
-  render() {
-    const { courses, user, showCourseSelector } = this.props
-    let courseOptions = []
-    if (showCourseSelector) {
-      let userCourses = courses
-      if (!user.isAdmin) {
-        userCourses = courses.filter(
-          c => user.staffAssignments.indexOf(c.id) !== -1
-        )
-      }
-      courseOptions = userCourses.map(course => ({
-        value: course.id,
-        label: course.name,
-      }))
+  let courseOptions = []
+  if (showCourseSelector) {
+    let userCourses = courses
+    if (!user.isAdmin) {
+      userCourses = courses.filter(
+        c => user.staffAssignments.indexOf(c.id) !== -1
+      )
     }
-
-    return (
-      <Form autoComplete="off">
-        {showCourseSelector && (
-          <FormGroup row>
-            <Label for="course" sm={3}>
-              Course
-            </Label>
-            <Col sm={9}>
-              <Select
-                type="select"
-                name="course"
-                id="course"
-                onChange={this.handleInputChange}
-                value={this.state.course}
-                invalid={isInvalid(this.state.fieldErrors.course)}
-                options={courseOptions}
-              >
-                <option value="none" disabled>
-                  Select a course
-                </option>
-                {courseOptions}
-              </Select>
-              <FormFeedback
-                className={classnames({
-                  'd-block': !!this.state.fieldErrors.course,
-                })}
-              >
-                {this.state.fieldErrors.course}
-              </FormFeedback>
-            </Col>
-          </FormGroup>
-        )}
-        <FormGroup row>
-          <Label for="name" sm={3}>
-            Name
-          </Label>
-          <Col sm={9}>
-            <Input
-              type="text"
-              name="name"
-              placeholder="Office Hours"
-              onChange={this.handleInputChange}
-              onKeyDown={this.handleKeyPress}
-              value={this.state.name}
-              invalid={isInvalid(this.state.fieldErrors.name)}
-            />
-            <FormFeedback>{this.state.fieldErrors.name}</FormFeedback>
-          </Col>
-        </FormGroup>
-        <FormGroup row>
-          <Label for="fixedLocation" sm={3}>
-            Fixed location
-          </Label>
-          <Col sm={9}>
-            <CustomInput
-              id="fixedLocation"
-              type="switch"
-              name="fixedLocation"
-              defaultChecked={false}
-              onChange={this.handleInputChange}
-            />
-            <FormText color="muted">
-              If a queue is marked as fixed-location, students won&apos;t be
-              able to set their own location.
-            </FormText>
-          </Col>
-        </FormGroup>
-        <FormGroup row>
-          <Label for="isConfidential" sm={3}>
-            Confidential Queue
-          </Label>
-          <Col sm={9}>
-            <CustomInput
-              id="isConfidential"
-              type="switch"
-              name="isConfidential"
-              defaultChecked={false}
-              onChange={this.handleInputChange}
-            />
-            <FormText color="muted">
-              If a queue is marked as confidential, students won&apos;t be able
-              to see other student names and topics.
-            </FormText>
-          </Col>
-        </FormGroup>
-        <FormGroup row>
-          <Label for="location" sm={3}>
-            Location
-          </Label>
-          <Col sm={9}>
-            <Input
-              type="text"
-              name="location"
-              placeholder="Siebel 0222"
-              onChange={this.handleInputChange}
-              onKeyDown={this.handleKeyPress}
-              value={this.state.location}
-              invalid={isInvalid(this.state.fieldErrors.location)}
-            />
-            {this.state.fixedLocation ? (
-              <FormText color="muted">
-                Students will see this location when asking a question, but
-                won&apos;t be able to change it.
-              </FormText>
-            ) : (
-              <FormText color="muted">Setting a location is optional!</FormText>
-            )}
-            <FormFeedback>{this.state.fieldErrors.location}</FormFeedback>
-          </Col>
-        </FormGroup>
-        <FormGroup row className="mb-0">
-          <Col md={6}>
-            <Button
-              block
-              color="secondary"
-              type="button"
-              onClick={() => this.props.onCancel()}
-            >
-              Cancel
-            </Button>
-          </Col>
-          <Col md={6}>
-            <Button
-              block
-              color="primary"
-              type="button"
-              onClick={() => this.handleSubmit()}
-            >
-              Create
-            </Button>
-          </Col>
-        </FormGroup>
-      </Form>
-    )
+    courseOptions = userCourses.map(c => ({
+      value: c.id,
+      label: c.name,
+    }))
   }
+
+  return (
+    <Form autoComplete="off" onSubmit={handleSubmit}>
+      {showCourseSelector && (
+        <FormGroup row>
+          <Label for="course" sm={3}>
+            Course
+          </Label>
+          <Col sm={9}>
+            <Select
+              type="select"
+              name="course"
+              id="course"
+              onChange={item => setCourse(item)}
+              value={course}
+              invalid={isInvalid(fieldErrors.course)}
+              options={courseOptions}
+            >
+              <option value="none" disabled>
+                Select a course
+              </option>
+              {courseOptions}
+            </Select>
+            <FormFeedback
+              className={classnames({
+                // Need to do this because our custom Select component
+                // doesn't have the right Bootstrap classes for it to be shwon
+                // automatically
+                'd-block': isInvalid(fieldErrors.course),
+              })}
+            >
+              {fieldErrors.course}
+            </FormFeedback>
+          </Col>
+        </FormGroup>
+      )}
+      <FormGroup row>
+        <Label for="name" sm={3}>
+          Name
+        </Label>
+        <Col sm={9}>
+          <Input
+            type="text"
+            name="name"
+            placeholder="Office Hours"
+            {...name.bindToInput}
+            invalid={isInvalid(fieldErrors.name)}
+          />
+          <FormFeedback>{fieldErrors.name}</FormFeedback>
+        </Col>
+      </FormGroup>
+      <FormGroup row>
+        <Label for="fixedLocation" sm={3}>
+          Fixed location
+        </Label>
+        <Col sm={9}>
+          <CustomInput
+            id="fixedLocation"
+            type="switch"
+            name="fixedLocation"
+            defaultChecked={false}
+            onChange={e => fixedLocation.setValue(e.target.checked)}
+          />
+          <FormText color="muted">
+            If a queue is marked as fixed-location, students won&apos;t be able
+            to set their own location.
+          </FormText>
+        </Col>
+      </FormGroup>
+      <FormGroup row>
+        <Label for="isConfidential" sm={3}>
+          Confidential Queue
+        </Label>
+        <Col sm={9}>
+          <CustomInput
+            id="isConfidential"
+            type="switch"
+            name="isConfidential"
+            defaultChecked={false}
+            onChange={e => isConfidential.setValue(e.target.checked)}
+          />
+          <FormText color="muted">
+            If a queue is marked as confidential, students won&apos;t be able to
+            see other student names and topics.
+          </FormText>
+        </Col>
+      </FormGroup>
+      <FormGroup row>
+        <Label for="location" sm={3}>
+          Location
+        </Label>
+        <Col sm={9}>
+          <Input
+            type="text"
+            name="location"
+            placeholder="Siebel 0222"
+            {...location.bindToInput}
+            invalid={isInvalid(fieldErrors.location)}
+          />
+          {fixedLocation ? (
+            <FormText color="muted">
+              Students will see this location when asking a question, but
+              won&apos;t be able to change it.
+            </FormText>
+          ) : (
+            <FormText color="muted">Setting a location is optional!</FormText>
+          )}
+          <FormFeedback>{fieldErrors.location}</FormFeedback>
+        </Col>
+      </FormGroup>
+      <FormGroup row className="mb-0">
+        <Col md={6}>
+          <Button block color="secondary" type="submit">
+            Cancel
+          </Button>
+        </Col>
+        <Col md={6}>
+          <Button block color="primary" type="button" onClick={handleSubmit}>
+            Create
+          </Button>
+        </Col>
+      </FormGroup>
+    </Form>
+  )
 }
 
 NewQueue.defaultProps = {

--- a/src/components/NewQueue.js
+++ b/src/components/NewQueue.js
@@ -12,7 +12,9 @@ import {
   Button,
 } from 'reactstrap'
 import { connect } from 'react-redux'
+import classnames from 'classnames'
 
+import Select from './Select'
 import { mapObjectToArray } from '../util'
 
 const isInvalid = error => error !== undefined && error !== ''
@@ -96,7 +98,7 @@ class NewQueue extends React.Component {
 
   render() {
     const { courses, user, showCourseSelector } = this.props
-    let courseOptions
+    let courseOptions = []
     if (showCourseSelector) {
       let userCourses = courses
       if (!user.isAdmin) {
@@ -104,11 +106,10 @@ class NewQueue extends React.Component {
           c => user.staffAssignments.indexOf(c.id) !== -1
         )
       }
-      courseOptions = userCourses.map(course => (
-        <option value={course.id} key={course.id}>
-          {course.name}
-        </option>
-      ))
+      courseOptions = userCourses.map(course => ({
+        value: course.id,
+        label: course.name,
+      }))
     }
 
     return (
@@ -119,20 +120,27 @@ class NewQueue extends React.Component {
               Course
             </Label>
             <Col sm={9}>
-              <CustomInput
+              <Select
                 type="select"
                 name="course"
                 id="course"
                 onChange={this.handleInputChange}
                 value={this.state.course}
                 invalid={isInvalid(this.state.fieldErrors.course)}
+                options={courseOptions}
               >
                 <option value="none" disabled>
                   Select a course
                 </option>
                 {courseOptions}
-              </CustomInput>
-              <FormFeedback>{this.state.fieldErrors.course}</FormFeedback>
+              </Select>
+              <FormFeedback
+                className={classnames({
+                  'd-block': !!this.state.fieldErrors.course,
+                })}
+              >
+                {this.state.fieldErrors.course}
+              </FormFeedback>
             </Col>
           </FormGroup>
         )}

--- a/src/components/Select.jsx
+++ b/src/components/Select.jsx
@@ -2,7 +2,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import ReactSelect from 'react-select'
-import classnames from 'classnames'
 
 import { useTheme } from './ThemeProvider'
 

--- a/src/components/Select.jsx
+++ b/src/components/Select.jsx
@@ -12,7 +12,7 @@ const Select = props => {
     }),
     control: (provided, state) => ({
       boxShadow: state.isFocused ? '0 0 0 0.2rem rgba(0,123,255,.25)' : null,
-      transition: null,
+      transition: 'border-color .15s ease-in-out, box-shadow .15s ease-in-out',
       '&:hover': null,
     }),
     option: () => ({

--- a/src/components/Select.jsx
+++ b/src/components/Select.jsx
@@ -1,0 +1,90 @@
+/* eslint-disable no-nested-ternary */
+import React from 'react'
+import ReactSelect from 'react-select'
+import { useTheme } from './ThemeProvider'
+
+const Select = props => {
+  const { isDarkMode } = useTheme()
+
+  const customStylesCommon = {
+    menu: () => ({
+      marginTop: 0,
+    }),
+    control: (provided, state) => ({
+      boxShadow: state.isFocused ? '0 0 0 0.2rem rgba(0,123,255,.25)' : null,
+      '&:hover': null,
+    }),
+    option: (provided, state) => ({
+      cursor: 'pointer',
+      backgroundColor: state.isSelected
+        ? 'red'
+        : state.isFocused
+        ? 'blue'
+        : 'transparent',
+    }),
+  }
+
+  const customStylesLight = {
+    menu: (provided, state) => ({
+      ...provided,
+      ...customStylesCommon.menu(),
+    }),
+    control: (provided, state) => ({
+      ...provided,
+      ...customStylesCommon.control(provided, state),
+      backgroundColor: state.isDisabled ? '#e9ecef' : 'white',
+      borderColor: '#ced4da',
+    }),
+    option: (provided, state) => ({
+      ...provided,
+      ...customStylesCommon.option(provided, state),
+    }),
+  }
+
+  const customStylesDark = {
+    menu: (provided, state) => ({
+      ...provided,
+      ...customStylesCommon.menu(),
+      backgroundColor: '#222',
+    }),
+    control: (provided, state) => ({
+      wig3: console.log(state.menuIsOpen),
+      ...provided,
+      ...customStylesCommon.control(provided, state),
+      backgroundColor: 'rgba(255, 255, 255, 0.09)',
+      borderColor: '#595959',
+    }),
+    option: (provided, state) => ({
+      ...provided,
+      ...customStylesCommon.option(provided, state),
+      backgroundColor: state.isSelected
+        ? '#2c7be5'
+        : state.isFocused
+        ? '#5997eb'
+        : 'transparent',
+      ':active': {
+        backgroundColor: state.isSelected ? '#2c7be5' : '#4a8ee9',
+      },
+    }),
+    singleValue: provided => ({
+      ...provided,
+      color: '#fff',
+    }),
+  }
+
+  const theme = existingTheme => ({
+    ...existingTheme,
+    borderRadius: '0.25rem',
+    colors: {
+      ...existingTheme.colors,
+      primary: isDarkMode ? '#2c7be5' : '#007bff',
+      // neutral0: isDarkMode ? '#343a40' : existingTheme.colors.neutral0,
+    },
+  })
+
+  const styles = isDarkMode ? customStylesDark : customStylesLight
+
+  return <ReactSelect {...props} theme={theme} styles={styles} />
+}
+
+export default Select

--- a/src/components/Select.jsx
+++ b/src/components/Select.jsx
@@ -73,6 +73,10 @@ const Select = props => {
       ...provided,
       ...customStylesCommon.menuList(),
     }),
+    placeholder: provided => ({
+      ...provided,
+      color: '#939ca9',
+    }),
   }
 
   const themeColorsDark = {

--- a/src/components/Select.jsx
+++ b/src/components/Select.jsx
@@ -8,24 +8,24 @@ const Select = props => {
 
   const customStylesCommon = {
     menu: () => ({
-      marginTop: 0,
+      marginTop: '2px',
     }),
     control: (provided, state) => ({
       boxShadow: state.isFocused ? '0 0 0 0.2rem rgba(0,123,255,.25)' : null,
+      transition: null,
       '&:hover': null,
     }),
-    option: (provided, state) => ({
+    option: () => ({
       cursor: 'pointer',
-      backgroundColor: state.isSelected
-        ? 'red'
-        : state.isFocused
-        ? 'blue'
-        : 'transparent',
+    }),
+    menuList: () => ({
+      paddingTop: '0.5rem',
+      paddingBottom: '0.5rem',
     }),
   }
 
   const customStylesLight = {
-    menu: (provided, state) => ({
+    menu: provided => ({
       ...provided,
       ...customStylesCommon.menu(),
     }),
@@ -39,46 +39,69 @@ const Select = props => {
       ...provided,
       ...customStylesCommon.option(provided, state),
     }),
+    menuList: provided => ({
+      ...provided,
+      ...customStylesCommon.menuList(),
+    }),
   }
 
   const customStylesDark = {
-    menu: (provided, state) => ({
+    menu: provided => ({
       ...provided,
       ...customStylesCommon.menu(),
-      backgroundColor: '#222',
+      backgroundColor: '#464c50',
     }),
     control: (provided, state) => ({
-      wig3: console.log(state.menuIsOpen),
       ...provided,
       ...customStylesCommon.control(provided, state),
-      backgroundColor: 'rgba(255, 255, 255, 0.09)',
+      backgroundColor: '#464c50',
       borderColor: '#595959',
     }),
     option: (provided, state) => ({
       ...provided,
       ...customStylesCommon.option(provided, state),
-      backgroundColor: state.isSelected
-        ? '#2c7be5'
-        : state.isFocused
-        ? '#5997eb'
-        : 'transparent',
-      ':active': {
-        backgroundColor: state.isSelected ? '#2c7be5' : '#4a8ee9',
-      },
+      color: 'white',
     }),
     singleValue: provided => ({
       ...provided,
       color: '#fff',
     }),
+    menuList: provided => ({
+      ...provided,
+      ...customStylesCommon.menuList(),
+    }),
   }
+
+  const themeColorsDark = {
+    primary: '#2c7be5',
+    primary25: '#5997eb',
+    primary50: '#4a8ee9',
+    primary75: '',
+    neutral90: 'hsl(0, 0%, 100%)',
+    neutral80: 'hsl(0, 0%, 95%)',
+    neutral70: 'hsl(0, 0%, 90%)',
+    neutral60: 'hsl(0, 0%, 80%)',
+    neutral50: 'hsl(0, 0%, 70%)',
+    neutral40: 'hsl(0, 0%, 60%)',
+    neutral30: 'hsl(0, 0%, 50%)',
+    neutral20: 'hsl(0, 0%, 40%)',
+    neutral10: 'hsl(0, 0%, 30%)',
+    neutral5: 'hsl(0, 0%, 20%)',
+    neutral0: 'hsl(0, 0%, 10%)',
+  }
+
+  const themeColorsLight = {
+    primary: '#007bff',
+  }
+
+  const themeColors = isDarkMode ? themeColorsDark : themeColorsLight
 
   const theme = existingTheme => ({
     ...existingTheme,
     borderRadius: '0.25rem',
     colors: {
       ...existingTheme.colors,
-      primary: isDarkMode ? '#2c7be5' : '#007bff',
-      // neutral0: isDarkMode ? '#343a40' : existingTheme.colors.neutral0,
+      ...themeColors,
     },
   })
 

--- a/src/components/Select.jsx
+++ b/src/components/Select.jsx
@@ -1,6 +1,9 @@
 /* eslint-disable no-nested-ternary */
 import React from 'react'
+import PropTypes from 'prop-types'
 import ReactSelect from 'react-select'
+import classnames from 'classnames'
+
 import { useTheme } from './ThemeProvider'
 
 const Select = props => {
@@ -33,7 +36,7 @@ const Select = props => {
       ...provided,
       ...customStylesCommon.control(provided, state),
       backgroundColor: state.isDisabled ? '#e9ecef' : 'white',
-      borderColor: '#ced4da',
+      borderColor: props.invalid ? '#dc3545' : '#ced4da',
     }),
     option: (provided, state) => ({
       ...provided,
@@ -55,7 +58,7 @@ const Select = props => {
       ...provided,
       ...customStylesCommon.control(provided, state),
       backgroundColor: '#464c50',
-      borderColor: '#595959',
+      borderColor: props.invalid ? '#e63757' : '#595959',
     }),
     option: (provided, state) => ({
       ...provided,
@@ -108,6 +111,14 @@ const Select = props => {
   const styles = isDarkMode ? customStylesDark : customStylesLight
 
   return <ReactSelect {...props} theme={theme} styles={styles} />
+}
+
+Select.propTypes = {
+  invalid: PropTypes.bool,
+}
+
+Select.defaultProps = {
+  invalid: false,
 }
 
 export default Select

--- a/src/components/ThemeProvider.jsx
+++ b/src/components/ThemeProvider.jsx
@@ -24,7 +24,7 @@ const ThemeProvider = ({ children, isDarkMode: isDarkModeInitial }) => {
       classList.remove('darkmode')
     }
     // Save as a cookie so we can correctly SSR with dark styles
-    document.cookie = `darkmode=${isDarkMode}`
+    document.cookie = `darkmode=${isDarkMode};path=/`
   }, [isDarkMode])
   return (
     <>

--- a/src/components/admin/AdminUsersPanel.jsx
+++ b/src/components/admin/AdminUsersPanel.jsx
@@ -133,7 +133,7 @@ const AdminUsersPanel = props => {
     )
   }
   return (
-    <Card>
+    <Card className="mb-3">
       <CardHeader>
         <CardTitle tag="h5" className="mb-0">
           Admin users

--- a/src/components/admin/ThemePreviewPanel.jsx
+++ b/src/components/admin/ThemePreviewPanel.jsx
@@ -3,7 +3,7 @@ import { Card, CardHeader, CardTitle, CardBody, Button } from 'reactstrap'
 
 import { Link } from '../../routes'
 
-const ThemePreviewPanel = props => {
+const ThemePreviewPanel = () => {
   return (
     <Card className="mb-3">
       <CardHeader>

--- a/src/components/admin/ThemePreviewPanel.jsx
+++ b/src/components/admin/ThemePreviewPanel.jsx
@@ -1,0 +1,30 @@
+import React from 'react'
+import { Card, CardHeader, CardTitle, CardBody, Button } from 'reactstrap'
+
+import { Link } from '../../routes'
+
+const ThemePreviewPanel = props => {
+  return (
+    <Card className="mb-3">
+      <CardHeader>
+        <CardTitle tag="h5" className="mb-0">
+          Theme preview
+        </CardTitle>
+      </CardHeader>
+      <CardBody>
+        <p>
+          The Queue supports both light and dark themes. Admins can use the
+          theme preview page to see a variety of Bootstrap components and how
+          they look under each theme.
+        </p>
+        <Link passHref route="adminThemePreview">
+          <Button tag="a" color="primary">
+            Preview themes
+          </Button>
+        </Link>
+      </CardBody>
+    </Card>
+  )
+}
+
+export default ThemePreviewPanel

--- a/src/components/darkmode.scss
+++ b/src/components/darkmode.scss
@@ -43,20 +43,6 @@ $theme-text-colors: (
   @return darken($color, 7.5%);
 }
 
-$color-primary: #2c7be5;
-$color-primary-border: #2c7be5;
-$color-primary-hover: #1a68d1;
-$color-primary-hover-border: #1862c6;
-
-$color-success: #00d97e !important;
-$color-success-border: #00d97e !important;
-
-$color-warning: #f6c343;
-$color-warning-border: #f6c343;
-
-$color-danger: #e63757;
-$color-danger-border: #e63757;
-
 body.darkmode {
   color: $text-color !important;
   background-color: $page-background !important;
@@ -175,12 +161,12 @@ body.darkmode {
 
   .dropdown-item.active,
   .dropdown-item:active {
-    background-color: $color-primary !important;
+    background-color: $primary !important;
   }
 
   .custom-control-input:checked ~ .custom-control-label::before {
-    background-color: $color-primary !important;
-    border-color: $color-primary-border !important;
+    background-color: $primary !important;
+    border-color: $primary !important;
   }
 
   /* Modals */

--- a/src/components/darkmode.scss
+++ b/src/components/darkmode.scss
@@ -1,5 +1,6 @@
 $page-background: #222;
 $dark-background: #343a40;
+$control-background: #464c50;
 $dark-border: #444;
 $text-color: #fff;
 $tab-border: rgba(0, 0, 0, 0.25);
@@ -130,12 +131,16 @@ body.darkmode {
 
   .dropdown-menu {
     color: $text-color !important;
-    background-color: $page-background !important;
+    background-color: $control-background !important;
     border: 1px solod $dark-border !important;
   }
 
   .dropdown-item {
     color: $text-color !important;
+
+    &:hover {
+      background-color: lighten($control-background, 10%);
+    }
 
     &:hover,
     &:focus,
@@ -144,11 +149,16 @@ body.darkmode {
     }
   }
 
+  .dropdown-item.active,
+  .dropdown-item:active {
+    background-color: $primary !important;
+  }
+
   /* Forms & inputs */
 
   .form-control,
   .custom-select {
-    background-color: rgba(255, 255, 255, 0.09) !important;
+    background-color: $control-background !important;
     border: 1px solid #595959 !important;
     color: $text-color !important;
   }
@@ -158,11 +168,6 @@ body.darkmode {
     background-color: $dark-border !important;
     color: #adb5bd !important;
     border-color: transparent !important;
-  }
-
-  .dropdown-item.active,
-  .dropdown-item:active {
-    background-color: $primary !important;
   }
 
   .custom-control-input:checked ~ .custom-control-label::before {

--- a/src/components/darkmode.scss
+++ b/src/components/darkmode.scss
@@ -146,7 +146,8 @@ body.darkmode {
 
   /* Forms & inputs */
 
-  .form-control {
+  .form-control,
+  .custom-select {
     background-color: rgba(255, 255, 255, 0.09) !important;
     border: 1px solid #595959 !important;
     color: $text-color !important;

--- a/src/components/darkmode.scss
+++ b/src/components/darkmode.scss
@@ -163,6 +163,10 @@ body.darkmode {
     color: $text-color !important;
   }
 
+  .form-control.is-invalid {
+    border-color: $danger !important;
+  }
+
   .input-group > .input-group-append > .input-group-text,
   .input-group > .input-group-prepend > .input-group-text {
     background-color: $dark-border !important;

--- a/src/components/darkmode.scss
+++ b/src/components/darkmode.scss
@@ -23,7 +23,7 @@ $theme-colors: map-merge(
     'warning': $warning,
     'danger': $danger,
     'dark': $dark-background,
-    'light': $light,
+    'light': $dark-background,
   ),
   $theme-colors
 );
@@ -36,7 +36,7 @@ $theme-text-colors: (
   'warning': $dark-background,
   'danger': $text-color,
   'dark': $text-color,
-  'light': $dark-background,
+  'light': $text-color,
 );
 
 @function border($color) {
@@ -64,9 +64,9 @@ body.darkmode {
   /* Content */
 
   a {
-    color: $color-primary;
+    color: $primary;
     &:hover {
-      color: darken($color-primary, 7.5%);
+      color: darken($primary, 7.5%);
     }
   }
 
@@ -218,10 +218,9 @@ body.darkmode {
     .bg-#{$color} {
       background-color: $value !important;
     }
-  }
-
-  .bg-light {
-    background-color: $dark-background !important;
+    .border-#{$color} {
+      border-color: $value !important;
+    }
   }
 
   .text-muted {

--- a/src/components/darkmode.scss
+++ b/src/components/darkmode.scss
@@ -4,8 +4,36 @@ $dark-border: #444;
 $text-color: #fff;
 $tab-border: rgba(0, 0, 0, 0.25);
 
+$primary: #2c7be5;
+$secondary: #6e84a3;
+$success: #00d97e;
+$info: #39afd1;
+$warning: #f6c343;
+$danger: #e63757;
+$dark: #222;
+
+$theme-colors: () !default;
+$theme-colors: map-merge(
+  (
+    'primary': $primary,
+    'secondary': $secondary,
+    'success': $success,
+    'info': $info,
+    'warning': $warning,
+    'danger': $danger,
+    'dark': $dark-background,
+  ),
+  $theme-colors
+);
+
+@function border($color) {
+  @return darken($color, 7.5%);
+}
+
 $color-primary: #2c7be5;
 $color-primary-border: #2c7be5;
+$color-primary-hover: #1a68d1;
+$color-primary-hover-border: #1862c6;
 
 $color-success: #00d97e !important;
 $color-success-border: #00d97e !important;
@@ -25,7 +53,7 @@ body.darkmode {
   a {
     color: $color-primary;
     &:hover {
-      color: darken($color-primary, 10%);
+      color: darken($color-primary, 7.5%);
     }
   }
 
@@ -35,53 +63,56 @@ body.darkmode {
 
   /* Alerts */
 
-  .alert-success {
-    color: $page-background !important;
-    background-color: $color-success !important;
-    border-color: $color-success-border !important;
+  @each $color, $value in $theme-colors {
+    .alert-#{$color} {
+      color: $page-background !important;
+      background-color: $value !important;
+      border-color: border($value) !important;
+    }
   }
 
-  .alert-warning {
-    color: $page-background;
-    background-color: $color-warning !important;
-    border-color: $color-warning-border !important;
-  }
+  /* Badges */
 
-  .alert-danger {
-    color: $text-color !important;
-    background-color: $color-danger !important;
-    border-color: $color-danger-border !important;
+  @each $color, $value in $theme-colors {
+    .badge-#{$color} {
+      color: $text-color !important;
+      background-color: $value !important;
+    }
   }
 
   /* Buttons */
 
-  .btn-primary {
-    color: $text-color !important;
-    background-color: $color-primary !important;
-    border-color: $color-primary-border !important;
-  }
-
-  .btn-outline-primary {
-    color: $color-primary !important;
-    border-color: $color-primary !important;
-    &:hover,
-    &:active {
+  @each $color, $value in $theme-colors {
+    .btn-#{$color} {
       color: $text-color !important;
+      background-color: $value !important;
+      border-color: $value !important;
+
+      &:hover {
+        background-color: darken($value, 7.5%) !important;
+        border-color: darken($value, 10%) !important;
+      }
+
+      &:active {
+        background-color: darken($value, 10%) !important;
+        border-color: darken($value, 12.5%) !important;
+      }
     }
-  }
 
-  .btn-danger {
-    color: $text-color !important;
-    background-color: $color-danger !important;
-    border-color: $color-danger-border !important;
-  }
+    .btn-outline-#{$color} {
+      color: $value !important;
+      border-color: $value !important;
 
-  .btn-danger-outline {
-    color: $color-danger !important;
-    border-color: $color-danger !important;
-    &:hover,
-    &:active {
-      color: $text-color !important;
+      &:hover {
+        color: $text-color !important;
+        background-color: $value !important;
+      }
+
+      &:active {
+        color: $text-color !important;
+        background-color: darken($value, 7.5%);
+        border-color: darken($value, 10%);
+      }
     }
   }
 
@@ -156,30 +187,24 @@ body.darkmode {
 
   /* Navs */
 
+  .nav-tabs .nav-link:hover {
+    background-color: $dark-background !important;
+    border-color: transparent !important;
+    border-bottom-color: $tab-border !important;
+  }
+
   .nav-tabs .nav-link.active {
     background-color: $dark-background !important;
     color: inherit;
     border-color: $tab-border $tab-border transparent !important;
   }
 
-  .nav-link:hover {
-    background-color: $dark-background !important;
-    border-color: transparent !important;
-    border-bottom-color: $tab-border !important;
-  }
-
   /* Utilities */
 
-  .bg-primary {
-    background-color: $color-primary !important;
-  }
-
-  .bg-success {
-    background-color: $color-success !important;
-  }
-
-  .bg-danger {
-    background-color: $color-danger !important;
+  @each $color, $value in $theme-colors {
+    .bg-#{$color} {
+      background-color: $value !important;
+    }
   }
 
   .bg-light {

--- a/src/components/darkmode.scss
+++ b/src/components/darkmode.scss
@@ -11,6 +11,7 @@ $info: #39afd1;
 $warning: #f6c343;
 $danger: #e63757;
 $dark: #222;
+$light: #eee;
 
 $theme-colors: () !default;
 $theme-colors: map-merge(
@@ -22,8 +23,20 @@ $theme-colors: map-merge(
     'warning': $warning,
     'danger': $danger,
     'dark': $dark-background,
+    'light': $light,
   ),
   $theme-colors
+);
+
+$theme-text-colors: (
+  'primary': $text-color,
+  'secondary': $text-color,
+  'success': $text-color,
+  'info': $text-color,
+  'warning': $dark-background,
+  'danger': $text-color,
+  'dark': $text-color,
+  'light': $dark-background,
 );
 
 @function border($color) {
@@ -65,7 +78,7 @@ body.darkmode {
 
   @each $color, $value in $theme-colors {
     .alert-#{$color} {
-      color: $page-background !important;
+      color: map-get($theme-text-colors, $color) !important;
       background-color: $value !important;
       border-color: border($value) !important;
     }
@@ -75,7 +88,7 @@ body.darkmode {
 
   @each $color, $value in $theme-colors {
     .badge-#{$color} {
-      color: $text-color !important;
+      color: map-get($theme-text-colors, $color) !important;
       background-color: $value !important;
     }
   }
@@ -84,7 +97,7 @@ body.darkmode {
 
   @each $color, $value in $theme-colors {
     .btn-#{$color} {
-      color: $text-color !important;
+      color: map-get($theme-text-colors, $color) !important;
       background-color: $value !important;
       border-color: $value !important;
 
@@ -104,12 +117,12 @@ body.darkmode {
       border-color: $value !important;
 
       &:hover {
-        color: $text-color !important;
+        color: map-get($theme-text-colors, $color) !important;
         background-color: $value !important;
       }
 
       &:active {
-        color: $text-color !important;
+        color: map-get($theme-text-colors, $color) !important;
         background-color: darken($value, 7.5%);
         border-color: darken($value, 10%);
       }

--- a/src/components/darkmode.scss
+++ b/src/components/darkmode.scss
@@ -2,14 +2,90 @@ $page-background: #222;
 $dark-background: #343a40;
 $dark-border: #444;
 $text-color: #fff;
+$tab-border: rgba(0, 0, 0, 0.25);
+
+$color-primary: #2c7be5;
+$color-primary-border: #2c7be5;
+
+$color-success: #00d97e !important;
+$color-success-border: #00d97e !important;
+
+$color-warning: #f6c343;
+$color-warning-border: #f6c343;
+
+$color-danger: #e63757;
+$color-danger-border: #e63757;
 
 body.darkmode {
   color: $text-color !important;
   background-color: $page-background !important;
 
-  .text-muted {
-    color: #999 !important;
+  /* Content */
+
+  a {
+    color: $color-primary;
+    &:hover {
+      color: darken($color-primary, 10%);
+    }
   }
+
+  pre {
+    color: $text-color !important;
+  }
+
+  /* Alerts */
+
+  .alert-success {
+    color: $page-background !important;
+    background-color: $color-success !important;
+    border-color: $color-success-border !important;
+  }
+
+  .alert-warning {
+    color: $page-background;
+    background-color: $color-warning !important;
+    border-color: $color-warning-border !important;
+  }
+
+  .alert-danger {
+    color: $text-color !important;
+    background-color: $color-danger !important;
+    border-color: $color-danger-border !important;
+  }
+
+  /* Buttons */
+
+  .btn-primary {
+    color: $text-color !important;
+    background-color: $color-primary !important;
+    border-color: $color-primary-border !important;
+  }
+
+  .btn-outline-primary {
+    color: $color-primary !important;
+    border-color: $color-primary !important;
+    &:hover,
+    &:active {
+      color: $text-color !important;
+    }
+  }
+
+  .btn-danger {
+    color: $text-color !important;
+    background-color: $color-danger !important;
+    border-color: $color-danger-border !important;
+  }
+
+  .btn-danger-outline {
+    color: $color-danger !important;
+    border-color: $color-danger !important;
+    &:hover,
+    &:active {
+      color: $text-color !important;
+    }
+  }
+
+  /* Cards */
 
   .card,
   .list-group-item {
@@ -20,41 +96,7 @@ body.darkmode {
     background-color: rgba(0, 0, 0, 0.1) !important;
   }
 
-  .modal-content {
-    background-color: $dark-background !important;
-    border: 1px solid $dark-border !important;
-  }
-
-  .modal-header {
-    border-bottom: 1px solid $dark-border !important;
-  }
-
-  .modal-footer {
-    border-top: 1px solid $dark-border !important;
-  }
-
-  .form-control {
-    background-color: rgba(255, 255, 255, 0.09) !important;
-    border: 1px solid #595959 !important;
-    color: $text-color !important;
-  }
-
-  .nav-tabs .nav-link.active {
-    background-color: transparent !important;
-    color: inherit;
-    border-color: $dark-border $dark-border transparent !important;
-  }
-  .nav-link:hover {
-    border-color: $dark-border $dark-border $dark-border !important;
-  }
-
-  .bg-light {
-    background-color: $dark-background !important;
-  }
-
-  pre {
-    color: $text-color !important;
-  }
+  /* Dropdowns */
 
   .dropdown-menu {
     color: $text-color !important;
@@ -72,6 +114,14 @@ body.darkmode {
     }
   }
 
+  /* Forms & inputs */
+
+  .form-control {
+    background-color: rgba(255, 255, 255, 0.09) !important;
+    border: 1px solid #595959 !important;
+    color: $text-color !important;
+  }
+
   .input-group > .input-group-append > .input-group-text,
   .input-group > .input-group-prepend > .input-group-text {
     background-color: $dark-border !important;
@@ -79,21 +129,64 @@ body.darkmode {
     border-color: transparent !important;
   }
 
-  .alert-success {
-    color: $page-background !important;
-    background-color: #00d97e !important;
-    border-color: #00d97e !important;
+  .dropdown-item.active,
+  .dropdown-item:active {
+    background-color: $color-primary !important;
   }
 
-  .alert-warning {
-    color: $page-background;
-    background-color: #f6c343;
-    border-color: #f6c343;
+  .custom-control-input:checked ~ .custom-control-label::before {
+    background-color: $color-primary !important;
+    border-color: $color-primary-border !important;
   }
 
-  .alert-danger {
-    color: $text-color;
-    background-color: #e63757;
-    border-color: #e63757;
+  /* Modals */
+
+  .modal-content {
+    background-color: $dark-background !important;
+    border: 1px solid $dark-border !important;
+  }
+
+  .modal-header {
+    border-bottom: 1px solid $dark-border !important;
+  }
+
+  .modal-footer {
+    border-top: 1px solid $dark-border !important;
+  }
+
+  /* Navs */
+
+  .nav-tabs .nav-link.active {
+    background-color: $dark-background !important;
+    color: inherit;
+    border-color: $tab-border $tab-border transparent !important;
+  }
+
+  .nav-link:hover {
+    background-color: $dark-background !important;
+    border-color: transparent !important;
+    border-bottom-color: $tab-border !important;
+  }
+
+  /* Utilities */
+
+  .bg-primary {
+    background-color: $color-primary !important;
+  }
+
+  .bg-success {
+    background-color: $color-success !important;
+  }
+
+  .bg-danger {
+    background-color: $color-danger !important;
+  }
+
+  .bg-light {
+    background-color: $dark-background !important;
+  }
+
+  .text-muted {
+    color: #999 !important;
   }
 }

--- a/src/components/darkmode.scss
+++ b/src/components/darkmode.scss
@@ -167,6 +167,17 @@ body.darkmode {
     border-color: $danger !important;
   }
 
+  .form-control:-ms-input-placeholder,
+  .form-control::-ms-input-placeholder {
+    color: #939ca9;
+    opacity: 1;
+  }
+
+  .form-control::placeholder {
+    color: #939ca9;
+    opacity: 1;
+  }
+
   .input-group > .input-group-append > .input-group-text,
   .input-group > .input-group-prepend > .input-group-text {
     background-color: $dark-border !important;

--- a/src/pages/adminIndex.js
+++ b/src/pages/adminIndex.js
@@ -4,11 +4,13 @@ import { Container } from 'reactstrap'
 
 import PageWithUser from '../components/PageWithUser'
 import AdminUsersPanel from '../components/admin/AdminUsersPanel'
+import ThemePreviewPanel from '../components/admin/ThemePreviewPanel'
 
 const AdminIndex = ({ user }) => (
   <Container>
     <h1 className="display-4">Admin</h1>
     <AdminUsersPanel user={user} />
+    <ThemePreviewPanel />
   </Container>
 )
 

--- a/src/pages/adminThemePreview.jsx
+++ b/src/pages/adminThemePreview.jsx
@@ -4,6 +4,8 @@ import {
   Alert,
   Badge,
   Button,
+  Card,
+  CardBody,
   Input,
   FormGroup,
   ModalHeader,
@@ -65,12 +67,16 @@ const AdminThemePreview = () => {
           {color}
         </Button>
       ))}
+      <Header>Cards</Header>
+      <Card>
+        <CardBody>This is some card content.</CardBody>
+      </Card>
       <Header>Forms</Header>
       <FormGroup>
         <Input />
       </FormGroup>
       <FormGroup>
-        <Input disabled />
+        <Input disabled placeholder="Disabled input" />
       </FormGroup>
       <FormGroup>
         <Select options={selectOptions} />
@@ -78,6 +84,22 @@ const AdminThemePreview = () => {
       <FormGroup>
         <Select options={selectOptions} isDisabled />
       </FormGroup>
+      <Card>
+        <CardBody>
+          <FormGroup>
+            <Input />
+          </FormGroup>
+          <FormGroup>
+            <Input disabled placeholder="Disabled input" />
+          </FormGroup>
+          <FormGroup>
+            <Select options={selectOptions} />
+          </FormGroup>
+          <FormGroup>
+            <Select options={selectOptions} isDisabled />
+          </FormGroup>
+        </CardBody>
+      </Card>
       <Header>Modals</Header>
       <div
         className="modal"

--- a/src/pages/adminThemePreview.jsx
+++ b/src/pages/adminThemePreview.jsx
@@ -30,7 +30,7 @@ const AdminThemePreview = () => {
     <Container>
       <Header>Alerts</Header>
       {colors.map(color => (
-        <Alert color={color} key={color}>
+        <Alert color={color} key={color} fade={false}>
           Here&apos;s a {color} alert. Neat, huh?
         </Alert>
       ))}
@@ -76,7 +76,9 @@ const AdminThemePreview = () => {
       </div>
       <Header>Background utilities</Header>
       {colors.map(color => (
-        <div className={`p-3 mb-3 bg-${color}`}>bg-{color}</div>
+        <div className={`p-3 mb-3 bg-${color}`} key={color}>
+          bg-{color}
+        </div>
       ))}
     </Container>
   )

--- a/src/pages/adminThemePreview.jsx
+++ b/src/pages/adminThemePreview.jsx
@@ -1,0 +1,45 @@
+import React from 'react'
+import { Container, Alert, Badge, Button } from 'reactstrap'
+import PageWithUser from '../components/PageWithUser'
+
+const colors = [
+  'primary',
+  'secondary',
+  'success',
+  'info',
+  'warning',
+  'danger',
+  'dark',
+  'light',
+]
+
+const AdminThemePreview = () => {
+  return (
+    <Container>
+      <h1>Alerts</h1>
+      {colors.map(color => (
+        <Alert color={color} key={color}>
+          Here&apos;s a {color} alert. Neat, huh?
+        </Alert>
+      ))}
+      <h1>Badges</h1>
+      {colors.map(color => (
+        <Badge color={color} key={color} className="mr-2 mb-2">
+          {color}
+        </Badge>
+      ))}
+      <h1>Buttons</h1>
+      {colors.map(color => (
+        <Button color={color} className="mr-3 mb-3" key={color}>
+          {color}
+        </Button>
+      ))}
+      <h1>Background utilities</h1>
+      {colors.map(color => (
+        <div className={`p-3 mb-3 bg-${color}`}>bg-{color}</div>
+      ))}
+    </Container>
+  )
+}
+
+export default PageWithUser(AdminThemePreview, { requireAdmin: true })

--- a/src/pages/adminThemePreview.jsx
+++ b/src/pages/adminThemePreview.jsx
@@ -1,5 +1,14 @@
 import React from 'react'
-import { Container, Alert, Badge, Button } from 'reactstrap'
+import {
+  Container,
+  Alert,
+  Badge,
+  Button,
+  Modal,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+} from 'reactstrap'
 import PageWithUser from '../components/PageWithUser'
 
 const colors = [
@@ -13,28 +22,59 @@ const colors = [
   'light',
 ]
 
+// eslint-disable-next-line react/prop-types
+const Header = ({ children }) => <h1 className="mt-4">{children}</h1>
+
 const AdminThemePreview = () => {
   return (
     <Container>
-      <h1>Alerts</h1>
+      <Header>Alerts</Header>
       {colors.map(color => (
         <Alert color={color} key={color}>
           Here&apos;s a {color} alert. Neat, huh?
         </Alert>
       ))}
-      <h1>Badges</h1>
+      <Header>Badges</Header>
       {colors.map(color => (
         <Badge color={color} key={color} className="mr-2 mb-2">
           {color}
         </Badge>
       ))}
-      <h1>Buttons</h1>
+      <Header>Buttons</Header>
       {colors.map(color => (
         <Button color={color} className="mr-3 mb-3" key={color}>
           {color}
         </Button>
       ))}
-      <h1>Background utilities</h1>
+      <br />
+      {colors.map(color => (
+        <Button color={color} outline className="mr-3 mb-3" key={color}>
+          {color}
+        </Button>
+      ))}
+      <Header>Modals</Header>
+      <div
+        className="modal"
+        style={{
+          position: 'relative',
+          top: 'auto',
+          right: 'auto',
+          bottom: 'auto',
+          left: 'auto',
+          zIndex: 1,
+          display: 'block',
+        }}
+      >
+        <div className="modal-content">
+          <ModalHeader>Are you sure?</ModalHeader>
+          <ModalBody>Do you really want to do that?</ModalBody>
+          <ModalFooter>
+            <Button color="danger">Yes</Button>
+            <Button color="secondary">No</Button>
+          </ModalFooter>
+        </div>
+      </div>
+      <Header>Background utilities</Header>
       {colors.map(color => (
         <div className={`p-3 mb-3 bg-${color}`}>bg-{color}</div>
       ))}

--- a/src/pages/adminThemePreview.jsx
+++ b/src/pages/adminThemePreview.jsx
@@ -6,7 +6,14 @@ import {
   Button,
   Card,
   CardBody,
+  UncontrolledDropdown,
+  DropdownToggle,
+  DropdownMenu,
+  DropdownItem,
   Input,
+  InputGroup,
+  InputGroupAddon,
+  InputGroupText,
   FormGroup,
   ModalHeader,
   ModalBody,
@@ -71,9 +78,32 @@ const AdminThemePreview = () => {
       <Card>
         <CardBody>This is some card content.</CardBody>
       </Card>
+      <Header>Dropdowns</Header>
+      <UncontrolledDropdown>
+        <DropdownToggle caret>Dropdown</DropdownToggle>
+        <DropdownMenu>
+          <DropdownItem header>Header</DropdownItem>
+          <DropdownItem disabled>Action</DropdownItem>
+          <DropdownItem>Another Action</DropdownItem>
+          <DropdownItem divider />
+          <DropdownItem>Another Action</DropdownItem>
+        </DropdownMenu>
+      </UncontrolledDropdown>
       <Header>Forms</Header>
       <FormGroup>
         <Input />
+      </FormGroup>
+      <FormGroup>
+        <InputGroup>
+          <InputGroupAddon addonType="prepend">
+            <InputGroupText>$</InputGroupText>
+            <InputGroupText>$</InputGroupText>
+          </InputGroupAddon>
+          <Input placeholder="Dolla dolla billz yo!" />
+          <InputGroupAddon addonType="append">
+            <Button color="primary">Swag</Button>
+          </InputGroupAddon>
+        </InputGroup>
       </FormGroup>
       <FormGroup>
         <Input disabled placeholder="Disabled input" />
@@ -88,6 +118,18 @@ const AdminThemePreview = () => {
         <CardBody>
           <FormGroup>
             <Input />
+          </FormGroup>
+          <FormGroup>
+            <InputGroup>
+              <InputGroupAddon addonType="prepend">
+                <InputGroupText>$</InputGroupText>
+                <InputGroupText>$</InputGroupText>
+              </InputGroupAddon>
+              <Input placeholder="Dolla dolla billz yo!" />
+              <InputGroupAddon addonType="append">
+                <Button color="primary">Swag</Button>
+              </InputGroupAddon>
+            </InputGroup>
           </FormGroup>
           <FormGroup>
             <Input disabled placeholder="Disabled input" />

--- a/src/pages/adminThemePreview.jsx
+++ b/src/pages/adminThemePreview.jsx
@@ -4,12 +4,14 @@ import {
   Alert,
   Badge,
   Button,
-  Modal,
+  Input,
+  FormGroup,
   ModalHeader,
   ModalBody,
   ModalFooter,
 } from 'reactstrap'
 import PageWithUser from '../components/PageWithUser'
+import Select from '../components/Select'
 
 const colors = [
   'primary',
@@ -26,6 +28,17 @@ const colors = [
 const Header = ({ children }) => <h1 className="mt-4">{children}</h1>
 
 const AdminThemePreview = () => {
+  const selectOptions = [
+    {
+      value: 'thing',
+      label: 'First thing',
+    },
+    {
+      value: 'thing2',
+      label: 'Second thing',
+    },
+  ]
+
   return (
     <Container>
       <Header>Alerts</Header>
@@ -52,6 +65,19 @@ const AdminThemePreview = () => {
           {color}
         </Button>
       ))}
+      <Header>Forms</Header>
+      <FormGroup>
+        <Input />
+      </FormGroup>
+      <FormGroup>
+        <Input disabled />
+      </FormGroup>
+      <FormGroup>
+        <Select options={selectOptions} />
+      </FormGroup>
+      <FormGroup>
+        <Select options={selectOptions} isDisabled />
+      </FormGroup>
       <Header>Modals</Header>
       <div
         className="modal"
@@ -61,7 +87,7 @@ const AdminThemePreview = () => {
           right: 'auto',
           bottom: 'auto',
           left: 'auto',
-          zIndex: 1,
+          zIndex: 0,
           display: 'block',
         }}
       >

--- a/src/routes.js
+++ b/src/routes.js
@@ -20,5 +20,6 @@ routes
   .add('createQueue', withBaseUrl('/course/:courseId/queue/create'))
   .add('userSettings', withBaseUrl('/settings'))
   .add('adminIndex', withBaseUrl('/admin'))
+  .add('adminThemePreview', withBaseUrl('/admin/theme'))
 
 module.exports = routes


### PR DESCRIPTION
* Extend styles with slightly tweaked colors for buttons, alerts, etc. based on [DashKit](https://themes.getbootstrap.com/product/dashkit-admin-dashboard-template/).
* Add a page for admins where they can preview how a variety of Bootstrap components look with our themes.
* Use explicit path for darkmode cookie to avoid differing settings between pages.