### PR TITLE
Trust information from the Apache proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ with the current semantic version and the next changes should go under a **[Next
 
 * Refine dark mode: better styles, new Bootstrap colors, and a custom select component. ([@nwalters512](https://github.com/nwalters512) in [#279](https://github.com/illinois/queue/pull/279))
 * Add TypeScript support to all build tooling; add some basic types to existing code. ([@nwalters512](https://github.com/nwalters512) in [#281](https://github.com/illinois/queue/pull/281))
+* Configure Express to know that we're running behind a proxy. ([@nwalters512](https://github.com/nwalters512) in [#284](https://github.com/illinois/queue/pull/284))
 
 ## v1.2.0
 

--- a/src/app.js
+++ b/src/app.js
@@ -7,6 +7,10 @@ const rewrite = require('express-urlrewrite')
 const { logger } = require('./util/logger')
 const { baseUrl, isDev, isNow } = require('./util')
 
+// We're probably running behind a proxy - trust them and derive information
+// from the X-Forwarded-* headers: https://expressjs.com/en/guide/behind-proxies.html
+app.set('trust proxy', 'loopback')
+
 app.use(cookieParser())
 app.use(bodyParser.json())
 app.use(bodyParser.urlencoded({ extended: false }))

--- a/src/middleware/authnJwt.js
+++ b/src/middleware/authnJwt.js
@@ -1,6 +1,6 @@
 const { ApiError } = require('../api/util')
 const safeAsync = require('../middleware/safeAsync')
-const { getUserFromJwt } = require('../auth/util')
+const { getUserFromJwt, addJwtCookie } = require('../auth/util')
 
 module.exports = safeAsync(async (req, res, next) => {
   if (res.locals.userAuthn) {
@@ -22,6 +22,13 @@ module.exports = safeAsync(async (req, res, next) => {
     next(new ApiError(401, 'Invalid cookie'))
     return
   }
+
+  // This was done as a part of https://github.com/illinois/queue/pull/284 to
+  // quickly validate that our fix was working; otherwise we'd have to wait a
+  // month before seeing results since that's the maximum length of time that
+  // any old, non-secure cookies would last. This can probably be safely removed
+  // a month after that PR was deployed.
+  addJwtCookie(req, res, user)
 
   res.locals.userAuthn = user
   next()


### PR DESCRIPTION
Per https://expressjs.com/en/guide/behind-proxies.html, we should set the `trust proxy` Express variable so that we can get information about the request (for us, all we really care about is the protocol) from the `X-Forwarded-*` headers.