### PR TITLE
Bugfix: Backticks are invalid in postgresql

### DIFF
--- a/src/models/Queue.js
+++ b/src/models/Queue.js
@@ -58,7 +58,7 @@ module.exports = (sequelize, DataTypes) => {
         include: [
           [
             sequelize.literal(
-              '(SELECT COUNT(`questions`.`id`) FROM `questions` WHERE `questions`.`queueId` = `queue`.`id` AND `questions`.`dequeueTime` IS NULL)'
+              '(SELECT COUNT("questions"."id") FROM "questions" WHERE "questions"."queueId" = "queue"."id" AND "questions"."dequeueTime" IS NULL)'
             ),
             'questionCount',
           ],


### PR DESCRIPTION
Backtick table name escaping is invalid for postgresql. This replaces backticks with double quotes.