### PR TITLE
Handle disabled button states in dark mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ with the current semantic version and the next changes should go under a **[Next
 
 ## [Next]
 
+* Handle disabled button states in dark mode ([@nwalters512](https://github.com/nwalters512) in [#294](https://github.com/illinois/queue/pull/294))
+
 ## v1.3.0
 * Add button to download all queue data for a course. ([@jackieo5023](https://github.com/jackieo5023) in [#290](https://github.com/illinois/queue/pull/290))
 

--- a/src/components/darkmode.scss
+++ b/src/components/darkmode.scss
@@ -88,12 +88,12 @@ body.darkmode {
       background-color: $value !important;
       border-color: $value !important;
 
-      &:hover {
+      &:hover:not(:disabled):not(.disabled) {
         background-color: darken($value, 7.5%) !important;
         border-color: darken($value, 10%) !important;
       }
 
-      &:active {
+      &:active:not(:disabled):not(.disabled) {
         background-color: darken($value, 10%) !important;
         border-color: darken($value, 12.5%) !important;
       }
@@ -103,12 +103,12 @@ body.darkmode {
       color: $value !important;
       border-color: $value !important;
 
-      &:hover {
+      &:hover:not(:disabled):not(.disabled) {
         color: map-get($theme-text-colors, $color) !important;
         background-color: $value !important;
       }
 
-      &:active {
+      &:active:not(:disabled):not(.disabled) {
         color: map-get($theme-text-colors, $color) !important;
         background-color: darken($value, 7.5%);
         border-color: darken($value, 10%);

--- a/src/pages/adminThemePreview.jsx
+++ b/src/pages/adminThemePreview.jsx
@@ -70,8 +70,26 @@ const AdminThemePreview = () => {
       ))}
       <br />
       {colors.map(color => (
+        <Button disabled color={color} className="mr-3 mb-3" key={color}>
+          {color}
+        </Button>
+      ))}
+      <br />
+      {colors.map(color => (
         <Button color={color} outline className="mr-3 mb-3" key={color}>
           {color}
+        </Button>
+      ))}
+      <br />
+      {colors.map(color => (
+        <Button
+          disabled
+          color={color}
+          outline
+          className="mr-3 mb-3"
+          key={color}
+        >
+          {color} - Disabled
         </Button>
       ))}
       <Header>Cards</Header>


### PR DESCRIPTION
Previously, hovering over disabled buttons in dark mode would show an unwanted hover state. This has been removed to match the normal light theme. Also includes disabled button states in the admin theme previewer.