### PR TITLE
Remove unused `shouldCheckFeedback` parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ When a new version is tagged, the changes since the last deploy should be labele
 with the current semantic version and the next changes should go under a **[Next]** header.
 
 ## [Next]
+* Fix question feedback submission. ([@james9909](https://github.com/jamse9909) in [#299](https://github.com/illinois/queue/pull/29))
 
 ## v1.4.0
 * Created a course settings page, which allows for unlisted courses and removal of the question feedback modal. ([@rittikaadhikari](https://github.com/rittikaadhikari) in [#293](https://github.com/illinois/queue/pull/293))

--- a/src/containers/QuestionListContainer.js
+++ b/src/containers/QuestionListContainer.js
@@ -32,13 +32,10 @@ const mapStateToProps = (state, props) => ({
 const mapDispatchToProps = (dispatch, { queueId }) => ({
   fetchQuestions: () => dispatch(fetchQuestions(queueId)),
   deleteQuestion: questionId => dispatch(deleteQuestion(queueId, questionId)),
-  // eslint-disable-next-line max-len
   updateQuestionBeingAnswered: (questionId, beingAnswered) =>
     dispatch(updateQuestionAnswering(questionId, beingAnswered)),
-  // eslint-disable-next-line max-len
   updateQuestion: (questionId, attributes) =>
     dispatch(updateQuestion(questionId, attributes)),
-  // eslint-disable-next-line max-len
   finishAnsweringQuestion: (questionId, feedback) =>
     dispatch(finishAnsweringQuestion(queueId, questionId, feedback)),
 })

--- a/src/containers/QuestionListContainer.js
+++ b/src/containers/QuestionListContainer.js
@@ -39,7 +39,7 @@ const mapDispatchToProps = (dispatch, { queueId }) => ({
   updateQuestion: (questionId, attributes) =>
     dispatch(updateQuestion(questionId, attributes)),
   // eslint-disable-next-line max-len
-  finishAnsweringQuestion: (questionId, shouldCheckFeedback, feedback) =>
+  finishAnsweringQuestion: (questionId, feedback) =>
     dispatch(finishAnsweringQuestion(queueId, questionId, feedback)),
 })
 


### PR DESCRIPTION
An unused parameter in the `finishAnsweringQuestion` prop introduced an issue where submitting question feedback would not properly send data to the server, causing an API error. This is preventing questions from being marked as answered for any queue that has question feedback enabled.