### PR TITLE
Update API doc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ before_install:
   - wget https://dev.mysql.com/get/mysql-apt-config_0.8.12-1_all.deb
   - sudo dpkg -i mysql-apt-config_0.8.12-1_all.deb
   - sudo apt-get update
-  - pip install mysql-connector-python==8.0.18 --user
   - sudo apt-get install mysql-utilities
+  - pip install mysql-connector-python==8.0.18 --user
   - mysql -e 'CREATE USER 'queue'@'localhost'; GRANT ALL PRIVILEGES ON *.* TO 'queue'@'localhost'; CREATE DATABASE queue; CREATE DATABASE queue_test;'
 script:
   - npm run build

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ before_install:
   - wget https://dev.mysql.com/get/mysql-apt-config_0.8.12-1_all.deb
   - sudo dpkg -i mysql-apt-config_0.8.12-1_all.deb
   - sudo apt-get update
+  - pip install dnspython --user
   - sudo apt-get install mysql-utilities
-  - pip install mysql-connector-python==8.0.18 --user
   - mysql -e 'CREATE USER 'queue'@'localhost'; GRANT ALL PRIVILEGES ON *.* TO 'queue'@'localhost'; CREATE DATABASE queue; CREATE DATABASE queue_test;'
 script:
   - npm run build

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ before_install:
   - wget https://dev.mysql.com/get/mysql-apt-config_0.8.12-1_all.deb
   - sudo dpkg -i mysql-apt-config_0.8.12-1_all.deb
   - sudo apt-get update
+  - sudo apt-get install mysql-connector-python=8.0.18
   - sudo apt-get install mysql-utilities
   - mysql -e 'CREATE USER 'queue'@'localhost'; GRANT ALL PRIVILEGES ON *.* TO 'queue'@'localhost'; CREATE DATABASE queue; CREATE DATABASE queue_test;'
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
   - wget https://dev.mysql.com/get/mysql-apt-config_0.8.12-1_all.deb
   - sudo dpkg -i mysql-apt-config_0.8.12-1_all.deb
   - sudo apt-get update
-  - pip install mysql-connector-python==8.0.18
+  - pip install mysql-connector-python==8.0.18 --user
   - sudo apt-get install mysql-utilities
   - mysql -e 'CREATE USER 'queue'@'localhost'; GRANT ALL PRIVILEGES ON *.* TO 'queue'@'localhost'; CREATE DATABASE queue; CREATE DATABASE queue_test;'
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,7 @@ before_install:
   - wget https://dev.mysql.com/get/mysql-apt-config_0.8.12-1_all.deb
   - sudo dpkg -i mysql-apt-config_0.8.12-1_all.deb
   - sudo apt-get update
-  - sudo apt-get install mysql-connector-python=8.0.18
-  - sudo apt-get install mysql-utilities
+  - sudo apt-get install mysql-utilities=1.3.5-2
   - mysql -e 'CREATE USER 'queue'@'localhost'; GRANT ALL PRIVILEGES ON *.* TO 'queue'@'localhost'; CREATE DATABASE queue; CREATE DATABASE queue_test;'
 script:
   - npm run build

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,8 @@ before_install:
   - wget https://dev.mysql.com/get/mysql-apt-config_0.8.12-1_all.deb
   - sudo dpkg -i mysql-apt-config_0.8.12-1_all.deb
   - sudo apt-get update
-  - sudo apt-get install mysql-utilities=1.3.5-2
+  - pip install mysql-connector-python==8.0.18
+  - sudo apt-get install mysql-utilities
   - mysql -e 'CREATE USER 'queue'@'localhost'; GRANT ALL PRIVILEGES ON *.* TO 'queue'@'localhost'; CREATE DATABASE queue; CREATE DATABASE queue_test;'
 script:
   - npm run build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ with the current semantic version and the next changes should go under a **[Next
 
 ## [Next]
 
+* Update API doc ([@jackieo5023](https://github.com/jackieo5023) in [#303](https://github.com/illinois/queue/pull/303))
+
 ## v1.4.1
 
 * Fix question feedback submission. ([@james9909](https://github.com/jamse9909) in [#299](https://github.com/illinois/queue/pull/299))

--- a/doc/API.md
+++ b/doc/API.md
@@ -10,31 +10,32 @@ There are a number of entities used by this application
 The following API routes are available to interact with these models. All paths
 described here are located under `/api/`.
 
-| Route                              | Verbs                  | Description                                         |
-| ---------------------------------- | ---------------------- | --------------------------------------------------- |
-| `/users`                           | `POST`                 | Create a new user                                   |
-| `/users`                           | `GET`                  | Get all users                                       |
-| `/users/me`                        | `GET/PATCH`            | Get/Update the currently authenticated user         |
-| `/users/:userId`                   | `GET`/                 | Get the given user                                  |
-| `/courses`                         | `POST`                 | Create a new course                                 |
-| `/courses`                         | `GET`                  | Get all courses                                     |
-| `/courses/:courseId`               | `GET`                  | Get the given course                                |
-| `/courses/:courseId/staff`         | `POST`                 | Add someone to course staff                         |
-| `/courses/:courseId/staff/:userId` | `DELETE`               | Remove someone from course staff                    |
-| `/queues`                          | `POST`                 | Create a new queue for the given course             |
-| `/queues`                          | `GET`                  | Get all open queues                                 |
-| `/queues/:queueId`                 | `GET`/`PATCH`/`DELETE` | Get/Update/Delete the given queue                   |
-| `/queues/:queueId/staff`           | `GET`                  | Gets the on-duty staff list for a specific queue    |
-| `/queues/:queueId/staff/:userId`   | `POST`                 | Joins the specified user to the specified queue     |
-| `/queues/:queueId/staff/:userId`   | `DELETE`               | Removes the specified user from the specified queue |
-| `/questions`                       | `POST`                 | Adds a question to a queue                          |
-| `/questions`                       | `GET`                  | Get all questions for a particular queue            |
-| `/questions/:questionId`           | `GET`                  | Get a particular question                           |
-| `/questions/:questionId`           | `PATCH`                | Updates a question's information                    |
-| `/questions/:questionId`           | `DELETE`               | Deletes a question from a queue                     |
-| `/questions/:questionId/answering` | `POST`                 | Mark a question as being answered                   |
-| `/questions/:questionId/answering` | `DELETE`               | Mark a question as no longer being answered         |
-| `/questions/:questionId/answered`  | `POST`                 | Mark the question as answered                       |
+| Route                               | Verbs                  | Description                                         |
+| ----------------------------------- | ---------------------- | --------------------------------------------------- |
+| `/users`                            | `GET`                  | Get all users                                       |
+| `/users/me`                         | `GET/PATCH`            | Get/Update the currently authenticated user         |
+| `/users/:userId`                    | `GET`                  | Get the given user                                  |
+| `/courses`                          | `POST`                 | Create a new course                                 |
+| `/courses`                          | `GET`                  | Get all courses                                     |
+| `/courses/:courseId`                | `GET/PATCH`            | Get/Update the given course                         |
+| `/courses/:courseId/data/questions` | `GET`                  | Get course queue data as a CSV                      |
+| `/courses/:courseId/staff`          | `POST`                 | Add someone to course staff                         |
+| `/courses/:courseId/staff/:userId`  | `DELETE`               | Remove someone from course staff                    |
+| `/queues`                           | `POST`                 | Create a new queue for the given course             |
+| `/queues`                           | `GET`                  | Get all open queues                                 |
+| `/queues/:queueId`                  | `GET`/`PATCH`/`DELETE` | Get/Update/Delete the given queue                   |
+| `/queues/:queueId/staff`            | `GET`                  | Gets the on-duty staff list for a specific queue    |
+| `/queues/:queueId/staff/:userId`    | `POST`                 | Joins the specified user to the specified queue     |
+| `/queues/:queueId/staff/:userId`    | `DELETE`               | Removes the specified user from the specified queue |
+| `/questions`                        | `POST`                 | Adds a question to a queue                          |
+| `/questions`                        | `GET`                  | Get all questions for a particular queue            |
+| `/questions`                        | `DELETE`               | Delete all questions for a particular queue         |
+| `/questions/:questionId`            | `GET`                  | Get a particular question                           |
+| `/questions/:questionId`            | `PATCH`                | Updates a question's information                    |
+| `/questions/:questionId`            | `DELETE`               | Deletes a question from a queue                     |
+| `/questions/:questionId/answering`  | `POST`                 | Mark a question as being answered                   |
+| `/questions/:questionId/answering`  | `DELETE`               | Mark a question as no longer being answered         |
+| `/questions/:questionId/answered`   | `POST`                 | Mark the question as answered                       |
 
 ## API Access Tokens
 


### PR DESCRIPTION
In an attempt to assist the Rokwire team with integrating the Queue, we are updating the API doc to represent the current state of the queue endpoints.

This PR:
* Adds relevant endpoints not already in the doc
    * `PATCH /courses/:courseId`
    * `GET /courses/:courseId/data/questions`
    * `DELETE /questions` 
* Deletes `POST /users` as it no longer exists

I did not add the endpoints for `/tokens` or `/users/admins` as I felt it was unnecessary, but if we should I can do that as well.