### PR TITLE
Fix: Autocomplete turned off for Staff

### DIFF
--- a/src/actions/course.js
+++ b/src/actions/course.js
@@ -139,17 +139,18 @@ const addCourseStaffFailure = makeActionCreator(
   'data'
 )
 
-export function addCourseStaff(courseId, userId) {
+export function addCourseStaff(courseId, userId, uid) {
   return dispatch => {
-    dispatch(addCourseStaffRequest(courseId, userId))
-
-    return axios.put(`/api/courses/${courseId}/staff/${userId}`).then(
-      res => dispatch(addCourseStaffSuccess(courseId, res.data)),
-      err => {
-        console.error(err)
-        dispatch(addCourseStaffFailure(err))
-      }
-    )
+    dispatch(addCourseStaffRequest(courseId, userId, uid))
+    return axios
+      .put(`/api/courses/${courseId}/staff`, { id: userId, uid })
+      .then(
+        res => dispatch(addCourseStaffSuccess(courseId, res.data)),
+        err => {
+          console.error(err)
+          dispatch(addCourseStaffFailure(err))
+        }
+      )
   }
 }
 

--- a/src/api/courses.js
+++ b/src/api/courses.js
@@ -7,7 +7,7 @@ const { matchedData } = require('express-validator/filter')
 const moment = require('moment')
 
 const { Course, Queue, Question, User, Sequelize } = require('../models')
-const { requireCourse, requireUser, failIfErrors } = require('./util')
+const { requireCourse, requireUser, failIfErrors, ApiError } = require('./util')
 const requireAdmin = require('../middleware/requireAdmin')
 const requireCourseStaff = require('../middleware/requireCourseStaff')
 const safeAsync = require('../middleware/safeAsync')
@@ -302,13 +302,29 @@ router.patch(
 )
 
 // Add someone to course staff
+// Need to add a user by :uid because staff have no access to get :userIds
 router.put(
-  '/:courseId/staff/:userId',
-  [requireCourseStaff, requireCourse, requireUser, failIfErrors],
+  '/:courseId/staff',
+  [requireCourseStaff, requireCourse, failIfErrors],
   safeAsync(async (req, res, _next) => {
-    const { user } = res.locals
+    const id = req.body.id ? req.body.id : null
+    const uid = req.body.uid ? req.body.uid : null
+    const query = id ? { where: { id } } : { where: { uid } }
+
+    if (!id && !uid) {
+      return _next(new ApiError(400, 'User id or uid expected'))
+    }
+
+    const user = await User.findOne(query)
+
+    if (!user) {
+      return _next(
+        new ApiError(404, 'User does not exist. Has user logged in?')
+      )
+    }
+
     await user.addStaffAssignment(res.locals.course.id)
-    res.status(201).send(user)
+    return res.status(201).send(user)
   })
 )
 

--- a/src/api/courses.test.js
+++ b/src/api/courses.test.js
@@ -272,31 +272,65 @@ describe('Courses API', () => {
     test('succeeds for admin', async () => {
       const request = await requestAsUser(app, 'admin@illinois.edu')
       // This is the "241staff" user
-      const res = await request.put('/api/courses/1/staff/4').send()
-      expect(res.statusCode).toBe(201)
-      expect(res.body.uid).toBe('241staff@illinois.edu')
+      const res1 = await request.put('/api/courses/1/staff').send({ id: 4 })
+      const res2 = await request
+        .put('/api/courses/1/staff')
+        .send({ uid: '241staff@illinois.edu' })
+      expect(res1.statusCode).toBe(201)
+      expect(res1.body.uid).toBe('241staff@illinois.edu')
+      expect(res2.statusCode).toBe(201)
+      expect(res2.body.uid).toBe('241staff@illinois.edu')
     })
 
     test('succeeds for course staff', async () => {
       const request = await requestAsUser(app, '225staff@illinois.edu')
       // This is the "241staff" user
-      const res = await request.put('/api/courses/1/staff/4').send()
-      expect(res.statusCode).toBe(201)
-      expect(res.body.uid).toBe('241staff@illinois.edu')
+      const res1 = await request.put('/api/courses/1/staff').send({ id: 4 })
+      const res2 = await request
+        .put('/api/courses/1/staff')
+        .send({ uid: '241staff@illinois.edu' })
+      expect(res1.statusCode).toBe(201)
+      expect(res2.statusCode).toBe(201)
+      expect(res1.body.uid).toBe('241staff@illinois.edu')
+      expect(res2.body.uid).toBe('241staff@illinois.edu')
     })
 
     test('fails for course staff of different course', async () => {
       const request = await requestAsUser(app, '241staff@illinois.edu')
       // This is the "241staff" user
-      const res = await request.put('/api/courses/1/staff/4').send()
-      expect(res.statusCode).toBe(403)
+      const res1 = await request.put('/api/courses/1/staff').send({ id: 4 })
+      const res2 = await request
+        .put('/api/courses/1/staff')
+        .send({ uid: '241staff@illinois.edu' })
+      expect(res1.statusCode).toBe(403)
+      expect(res2.statusCode).toBe(403)
     })
 
     test('fails for student', async () => {
       const request = await requestAsUser(app, '241staff@illinois.edu')
       // This is the "241staff" user
-      const res = await request.put('/api/courses/1/staff/4').send()
-      expect(res.statusCode).toBe(403)
+      const res1 = await request.put('/api/courses/1/staff').send({ id: 4 })
+      const res2 = await request
+        .put('/api/courses/1/staff')
+        .send({ uid: '241staff@illinois.edu' })
+      expect(res1.statusCode).toBe(403)
+      expect(res2.statusCode).toBe(403)
+    })
+
+    test('fails when adding non-existent user', async () => {
+      const request = await requestAsUser(app, 'admin@illinois.edu')
+      const res1 = await request.put('/api/courses/1/staff').send({ id: 99999 })
+      const res2 = await request
+        .put('/api/courses/1/staff')
+        .send({ uid: 'fakeuser@fake.com' })
+      expect(res1.statusCode).toBe(404)
+      expect(res2.statusCode).toBe(404)
+      expect(JSON.parse(res1.error.text).message).toBe(
+        'User does not exist. Has user logged in?'
+      )
+      expect(JSON.parse(res2.error.text).message).toBe(
+        'User does not exist. Has user logged in?'
+      )
     })
   })
 

--- a/src/components/AddStaff.js
+++ b/src/components/AddStaff.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react'
+import { connect } from 'react-redux'
 import PropTypes from 'prop-types'
 import {
   Form,
@@ -13,16 +14,21 @@ import UserAutocomplete from './UserAutocomplete'
 const { uidName, uidArticle } = getConfig().publicRuntimeConfig
 
 const AddStaff = props => {
+  const { user } = props
   const [pendingUser, setPendingUser] = useState([])
+  const [uidInput, setUidInput] = useState()
 
   const handleAddStaff = e => {
     if (e) e.preventDefault()
-    props.onAddStaff(pendingUser[0])
+    if (pendingUser[0]) {
+      return props.onAddStaff(pendingUser[0].id, null)
+    }
+    return props.onAddStaff(null, uidInput)
   }
 
   // We want to exclude existing staff from the autocompletion list
   const filterBy = option => {
-    return props.existingStaff.findIndex(user => user === option.id) === -1
+    return props.existingStaff.findIndex(u => u === option.id) === -1
   }
   return (
     <FormGroup>
@@ -35,6 +41,7 @@ const AddStaff = props => {
         <InputGroup>
           <UserAutocomplete
             id="user-input"
+            setUidInput={setUidInput}
             selected={pendingUser}
             onChange={setPendingUser}
             placeholder={`Enter ${uidArticle} ${uidName}`}
@@ -45,7 +52,7 @@ const AddStaff = props => {
               color="primary"
               type="button"
               onClick={handleAddStaff}
-              disabled={pendingUser.length === 0}
+              disabled={user.isAdmin && pendingUser.length === 0}
             >
               Add staff
             </Button>
@@ -57,6 +64,9 @@ const AddStaff = props => {
 }
 
 AddStaff.propTypes = {
+  user: PropTypes.shape({
+    isAdmin: PropTypes.bool,
+  }).isRequired,
   // This is just an array of user IDs (not UIDs)
   existingStaff: PropTypes.arrayOf(PropTypes.number),
   onAddStaff: PropTypes.func.isRequired,
@@ -66,4 +76,8 @@ AddStaff.defaultProps = {
   existingStaff: [],
 }
 
-export default AddStaff
+const mapStateToProps = state => ({
+  user: state.user.user,
+})
+
+export default connect(mapStateToProps)(AddStaff)

--- a/src/components/UserAutocomplete.jsx
+++ b/src/components/UserAutocomplete.jsx
@@ -1,10 +1,16 @@
 import React, { useState, useEffect } from 'react'
 import PropTypes from 'prop-types'
 import ReactDOM from 'react-dom'
+import { connect } from 'react-redux'
 import { useInput } from 'react-hanger'
 import { useDebounce } from 'use-debounce'
 import { CancelToken } from 'axios'
-import { AsyncTypeahead, Highlighter } from 'react-bootstrap-typeahead'
+import {
+  AsyncTypeahead,
+  Highlighter,
+  Menu,
+  MenuItem,
+} from 'react-bootstrap-typeahead'
 
 import 'react-bootstrap-typeahead/css/Typeahead.css'
 import 'react-bootstrap-typeahead/css/Typeahead-bs4.css'
@@ -12,34 +18,52 @@ import 'react-bootstrap-typeahead/css/Typeahead-bs4.css'
 import axios from '../actions/axios'
 
 const UserAutocomplete = props => {
+  const { user, setUidInput } = props
   const uidInput = useInput('')
   const [uidQuery] = useDebounce(uidInput.value, 300)
   const [userSuggestions, setUserSuggestions] = useState([])
   const [userSuggestionsLoading, setUserSuggestionsLoading] = useState(false)
+  const renderMenu = (results, menuProps) => {
+    // Hide the autocomplete when user is staff
+    if (!user.isAdmin) {
+      return <></>
+    }
+    const items = results.map((result, idx) => (
+      <MenuItem key={result.id} option={result} position={idx}>
+        <Highlighter search={menuProps.text}>{result.uid}</Highlighter>
+        {result.name && (
+          <span className="text-muted ml-2">({result.name})</span>
+        )}
+      </MenuItem>
+    ))
+    return <Menu {...menuProps}>{items}</Menu>
+  }
 
   useEffect(() => {
     if (!uidQuery) {
       return () => {}
     }
     const source = CancelToken.source()
-    setUserSuggestionsLoading(true)
-    axios
-      .get('/api/autocomplete/users', {
-        params: {
-          q: uidQuery,
-        },
-        cancelToken: source.token,
-      })
-      .then(res => {
-        ReactDOM.unstable_batchedUpdates(() => {
-          // The typeahead component will filter out existing admins
-          setUserSuggestions(res.data)
-          setUserSuggestionsLoading(false)
+    if (user.isAdmin) {
+      setUserSuggestionsLoading(true)
+      axios
+        .get('/api/autocomplete/users', {
+          params: {
+            q: uidQuery,
+          },
+          cancelToken: source.token,
         })
-      })
-      .catch(err => {
-        console.error(err)
-      })
+        .then(res => {
+          ReactDOM.unstable_batchedUpdates(() => {
+            // The typeahead component will filter out existing admins
+            setUserSuggestions(res.data)
+            setUserSuggestionsLoading(false)
+          })
+        })
+        .catch(err => {
+          console.error(err)
+        })
+    }
     return () => {
       source.cancel()
     }
@@ -55,7 +79,10 @@ const UserAutocomplete = props => {
         /* This is handled by hooks, but prop must be specified */
       }}
       labelKey="uid"
-      onInputChange={value => uidInput.setValue(value)}
+      onInputChange={value => {
+        uidInput.setValue(value)
+        setUidInput(value)
+      }}
       minLength={1}
       useCache={false}
       // Attempt to force Chrome to hide the native email autocomplete
@@ -63,27 +90,24 @@ const UserAutocomplete = props => {
         autoComplete: 'new-user-uid',
         ...inputProps,
       }}
-      renderMenuItemChildren={(option, typeaheadProps) => {
-        return (
-          <>
-            <Highlighter search={typeaheadProps.text}>{option.uid}</Highlighter>
-            {option.name && (
-              <span className="text-muted ml-2">({option.name})</span>
-            )}
-          </>
-        )
-      }}
+      renderMenu={renderMenu}
       {...restProps}
     />
   )
 }
 
 UserAutocomplete.propTypes = {
+  user: PropTypes.shape({
+    uid: PropTypes.string,
+    userId: PropTypes.string,
+    isAdmin: PropTypes.bool,
+  }).isRequired,
   selected: PropTypes.arrayOf(
     PropTypes.shape({
       uid: PropTypes.string,
     })
   ),
+  setUidInput: PropTypes.func.isRequired,
   onChange: PropTypes.func.isRequired,
   // We don't know exactly what these props will be
   // eslint-disable-next-line react/forbid-prop-types
@@ -95,4 +119,8 @@ UserAutocomplete.defaultProps = {
   inputProps: {},
 }
 
-export default UserAutocomplete
+const mapStateToProps = state => ({
+  user: state.user.user,
+})
+
+export default connect(mapStateToProps)(UserAutocomplete)

--- a/src/components/courseSettings/ManageStaffPanel.tsx
+++ b/src/components/courseSettings/ManageStaffPanel.tsx
@@ -27,7 +27,7 @@ interface ManageStaffPanelProps {
     name: string
   }[]
   removeCourseStaff: (courseId: number, userId: number) => void
-  addCourseStaff: (courseId: number, uid: string, name: string) => void
+  addCourseStaff: (courseId: number, userId: string, uid: string) => void
 }
 
 const ManageStaffPanel = ({
@@ -67,9 +67,8 @@ const ManageStaffPanel = ({
       </CardHeader>
       <CardBody>
         <AddStaff
-          onAddStaff={(staff: Record<string, string>) => {
-            const { id, name } = staff
-            addCourseStaff(course.id, id, name)
+          onAddStaff={(userId: string, uid: string) => {
+            addCourseStaff(course.id, userId, uid)
           }}
         />
         <ListGroup flush className="position-relative">

--- a/src/pages/courseSettings.js
+++ b/src/pages/courseSettings.js
@@ -111,8 +111,8 @@ const mapStateToProps = (state, ownProps) => ({
 
 const mapDispatchToProps = dispatch => ({
   fetchCourse: courseId => dispatch(fetchCourse(courseId)),
-  addCourseStaff: (courseId, uid, name) =>
-    dispatch(addCourseStaff(courseId, uid, name)),
+  addCourseStaff: (courseId, userId, uid) =>
+    dispatch(addCourseStaff(courseId, userId, uid)),
   removeCourseStaff: (courseId, userId) =>
     dispatch(removeCourseStaff(courseId, userId)),
   updateCourse: (courseId, attributes) =>


### PR DESCRIPTION
Description: A staff user would attempt to add another staff user and experience a permissions error where an Autocomplete component would attempt to fetch user information that the staff role should not have access to. It rightly resulted in a back-end error being received by the user on the front-end UI.

Fix: Enable autocorrect for the admin user role, but only allow manual entries for the staff user role.

Original issue filed here: https://github.com/illinois/queue/issues/305